### PR TITLE
Enable pushing of job groups

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,4 @@ jobs:
           APIKEY: "${{ secrets.APIKEY }}"
           APISECRET: "${{ secrets.APISECRET }}"
         run: |
-          #FIXME only do a dry run for now
-          ./tool.py --dry-run --push
+          ./tool.py --push


### PR DESCRIPTION
Merging this PR will make this git repo the authoritative place to define jobgroups for openqa.opensuse.org.

All job groups will automatically be prefixed with a header comment with a warning not to do local changes in openqa and pointing to this git repo and the correct file to change.


**Directly before merging** this PR, use 
```
./tool.py --fetch ; git diff
``` 
to check if there were any changes done in the meantime via the O3 webui and commit/push them to the master branch.