### PR TITLE
Setup job groups and schedules for Leap15.4 maintenance testing

### DIFF
--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -61,3 +61,6 @@
 94: opensuse_leap_micro_5.2_image
 95: opensuse_leap_micro_5.2_dvd
 96: d-installer
+97: opensuse_leap_15.4_incidents
+98: opensuse_leap_15.4_updates
+99: opensuse_leap_15.4_backports

--- a/job_groups/opensuse_leap_15.4_backports.yaml
+++ b/job_groups/opensuse_leap_15.4_backports.yaml
@@ -1,0 +1,41 @@
+---
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#       job_groups/opensuse_leap_15.4_backports.yaml       #
+############################################################
+defaults:
+  x86_64:
+    machine: 64bit-2G
+    priority: 50
+products:
+  opensuse-15.4-DVD-Backports-Incidents-x86_64:
+    distri: opensuse
+    flavor: DVD-Backports-Incidents
+    version: '15.4'
+scenarios:
+  x86_64:
+    opensuse-15.4-DVD-Backports-Incidents-x86_64:
+      - textmode:
+          machine: 64bit
+      - kde
+      - gnome:
+          machine: uefi
+          settings:
+            QEMUVGA: cirrus
+      - gnome:
+          machine: 64bit-2G
+          settings:
+            QEMUVGA: cirrus
+      - cryptlvm:
+          settings:
+            YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+      - install_with_updates_gnome:
+          settings:
+            QEMUVGA: cirrus
+      - install_with_updates_kde:
+          machine: uefi-2G

--- a/job_groups/opensuse_leap_15.4_incidents.yaml
+++ b/job_groups/opensuse_leap_15.4_incidents.yaml
@@ -1,0 +1,27 @@
+---
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#       job_groups/opensuse_leap_15.4_incidents.yaml       #
+############################################################
+
+defaults:
+  x86_64:
+    machine: 64bit-2G
+    priority: 50
+products:
+  opensuse-15.4-DVD-Incidents-x86_64:
+    distri: opensuse
+    flavor: DVD-Incidents
+    version: '15.4'
+scenarios:
+  x86_64:
+    opensuse-15.4-DVD-Incidents-x86_64:
+      - kde
+      - gnome
+      - cryptlvm:
+          machine: uefi-2G

--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -1,0 +1,63 @@
+---
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#        job_groups/opensuse_leap_15.4_updates.yaml        #
+############################################################
+defaults:
+  x86_64:
+    machine: 64bit
+    priority: 50
+products:
+  opensuse-15.4-DVD-Updates-x86_64:
+    distri: opensuse
+    flavor: DVD-Updates
+    version: '15.4'
+scenarios:
+  x86_64:
+    opensuse-15.4-DVD-Updates-x86_64:
+      - textmode:
+          machine: 64bit
+      - gnome:
+          machine: uefi
+          settings:
+            QEMUVGA: cirrus
+      - gnome:
+          machine: 64bit-2G
+          settings:
+            QEMUVGA: cirrus
+      - cryptlvm:
+          settings:
+            YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+      - install_with_updates_gnome:
+          machine: 64bit-2G
+          settings:
+            QEMUVGA: cirrus
+      - install_with_updates_kde:
+          machine: uefi-2G
+          # poo#95137
+          settings:
+            EXCLUDE_MODULES: 'kontact'
+      - create_hdd_gnome:
+          machine: 64bit
+      - create_hdd_gnome:
+          machine: uefi
+      - create_hdd_kde:
+          machine: uefi
+      - create_hdd_kde:
+          machine: 64bit
+      - create_hdd_gnome_libyui
+      - create_hdd_textmode
+      - extra_tests_on_kde
+      - gnuhealth
+      - toolkits
+      - openqa_bootstrap
+      # poo#107242
+      # - openqa_bootstrap_container
+      - yast2_firstboot
+      - extra_tests_misc
+      - kde


### PR DESCRIPTION
Created mediums: DVD-{Updates,Incidents,Backports-Incidents} in o3.
At the time of creating this PR, the default ISO has been set to the
lastest available - *Build230.2*, which might change in the future.
Test schedule has been reused from Leap15.3 maintenance.

- ticket: [[qe-core] Manually do the setup of Leap Updates in osd and o3](https://progress.opensuse.org/issues/111255)