### PR TITLE
Increase RAM in remote_vnc scenario

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -891,6 +891,7 @@ scenarios:
             SUPPORT_SERVER: '1'
             SUPPORT_SERVER_ROLES: dhcp,dns
             WORKER_CLASS: tap
+            QEMURAM: '2048'
             YAML_SCHEDULE: schedule/yast/opensuse/remote_vnc/remote_vnc_controller.yaml
           description: Controller performs remote installation via vnc to the target
           testsuite: null
@@ -904,6 +905,7 @@ scenarios:
             REMOTE_TARGET: vnc
             USE_SUPPORT_SERVER: '1'
             WORKER_CLASS: tap
+            QEMURAM: '2048'
             YAML_SCHEDULE: schedule/yast/opensuse/remote_vnc/remote_vnc_target.yaml
           description: The target of the vnc remote installation triggered by the controller
           testsuite: null


### PR DESCRIPTION
In order to tackle this redraw [failure](https://openqa.opensuse.org/tests/2337286#step/system_role/1) let's start by increasing ram in case it could help (I could try to run locally but it is taking ages to run MM tests in opensuse) and this setting doesn't hurt, can be reverted if the [bug](https://bugzilla.suse.com/show_bug.cgi?id=1199477) progresses or a test workaround is the only solution.
