### PR TITLE
Add INFLUXDB variable for JeOS jobs

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -72,6 +72,8 @@ scenarios:
     opensuse-Leap15.3-JeOS-for-kvm-and-xen-x86_64:
     - jeos:
         machine: 64bit_virtio-2G
+        settings:
+          INFLUXDB_SERVER: '35.158.113.219'
     - jeos:
         machine: uefi_virtio-2G
     - jeos-extra:

--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -7,6 +7,9 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #        job_groups/opensuse_leap_15.3_images.yaml         #
 ############################################################
+
+---
+
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -70,138 +73,138 @@ products:
 scenarios:
   x86_64:
     opensuse-Leap15.3-JeOS-for-kvm-and-xen-x86_64:
-    - jeos:
-        machine: 64bit_virtio-2G
-        settings:
-          INFLUXDB_SERVER: '35.158.113.219'
-    - jeos:
-        machine: uefi_virtio-2G
-    - jeos-extra:
-        machine: 64bit_virtio-2G
-        settings:
-          # Completely broken, no fix in sight (boo#1174315)
-          EXCLUDE_MODULES: "rails"
-    - jeos-container_host:
-        machine: 64bit_virtio-2G
-    - jeos-container_image:
-        machine: 64bit_virtio-2G
-        settings:
+      - jeos:
+          machine: 64bit_virtio-2G
+          settings:
+            INFLUXDB_SERVER: '35.158.113.219'
+      - jeos:
+          machine: uefi_virtio-2G
+      - jeos-extra:
+          machine: 64bit_virtio-2G
+          settings:
+            # Completely broken, no fix in sight (boo#1174315)
+            EXCLUDE_MODULES: "rails"
+      - jeos-container_host:
+          machine: 64bit_virtio-2G
+      - jeos-container_image:
+          machine: 64bit_virtio-2G
+          settings:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - jeos-filesystem:
-        machine: 64bit_virtio-2G
-    - jeos-ltp-containers:
-        machine: 64bit_virtio
-    - jeos-ltp-cve:
-        machine: 64bit_virtio
-    - jeos-ltp-dio:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls:
-        machine: 64bit_virtio
-    - jeos-ltp-commands:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls-ipc:
-        machine: 64bit_virtio
+      - jeos-filesystem:
+          machine: 64bit_virtio-2G
+      - jeos-ltp-containers:
+          machine: 64bit_virtio
+      - jeos-ltp-cve:
+          machine: 64bit_virtio
+      - jeos-ltp-dio:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls:
+          machine: 64bit_virtio
+      - jeos-ltp-commands:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls-ipc:
+          machine: 64bit_virtio
     opensuse-Leap15.3-GNOME-Live-x86_64:
-    - gnome-live:
-        machine: uefi-2G
-    - gnome-live:
-        machine: 64bit-2G
-    - gnome-live:
-        machine: uefi-usb-2G
-    - gnome-live:
-        machine: USBboot_64-2G
-    - mediacheck:
-        machine: 64bit
+      - gnome-live:
+          machine: uefi-2G
+      - gnome-live:
+          machine: 64bit-2G
+      - gnome-live:
+          machine: uefi-usb-2G
+      - gnome-live:
+          machine: USBboot_64-2G
+      - mediacheck:
+          machine: 64bit
     opensuse-Leap15.3-KDE-Live-x86_64:
-    - kde-live:
-        machine: uefi-usb-2G
-    - kde-live:
-        machine: 64bit-2G
-    - kde-live:
-        machine: USBboot_64-2G
-    - kde-live:
-        machine: uefi-2G
-    - mediacheck:
-        machine: 64bit
-    - kde-live_installation
-    - kde-live-wayland:
-        machine: 64bit_virtio-2G
-    - kde_live_upgrade_leap_42.3
-    - kde_live_upgrade_leap_15.0:
-        machine: 64bit
-        settings:
-          QEMU_VIRTIO_RNG: "0"
+      - kde-live:
+          machine: uefi-usb-2G
+      - kde-live:
+          machine: 64bit-2G
+      - kde-live:
+          machine: USBboot_64-2G
+      - kde-live:
+          machine: uefi-2G
+      - mediacheck:
+          machine: 64bit
+      - kde-live_installation
+      - kde-live-wayland:
+          machine: 64bit_virtio-2G
+      - kde_live_upgrade_leap_42.3
+      - kde_live_upgrade_leap_15.0:
+          machine: 64bit
+          settings:
+            QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.3-Rescue-CD-x86_64:
-    - rescue
-    - rescue:
-        machine: uefi-usb-2G
-    - mediacheck:
-        machine: 64bit
+      - rescue
+      - rescue:
+          machine: uefi-usb-2G
+      - mediacheck:
+          machine: 64bit
     opensuse-Leap15.3-XFCE-Live-x86_64:
-    - xfce-live
-    - xfce-live:
-        machine: uefi-usb-2G
-    - mediacheck
+      - xfce-live
+      - xfce-live:
+          machine: uefi-usb-2G
+      - mediacheck
     opensuse-15.3-Container-Image-x86_64:
-    - container_image_on_centos_host:
-        testsuite: container-image
-        description: 'Container image validation on CentOS 8.2'
-        settings:
+      - container_image_on_centos_host:
+          testsuite: container-image
+          description: 'Container image validation on CentOS 8.2'
+          settings:
             HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
             CONTAINER_RUNTIME: 'podman'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - container_image_on_ubuntu_host:
-        testsuite: container-image
-        description: 'Container image validation on Ubuntu 20.04'
-        settings:
+      - container_image_on_ubuntu_host:
+          testsuite: container-image
+          description: 'Container image validation on Ubuntu 20.04'
+          settings:
             HDD_1: 'ubuntu-20.04.1_1.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.3 GM'
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.3 GM'
+          settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - container_image_on_leap15.2_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.2 GM'
-        settings:
+      - container_image_on_leap15.2_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.2 GM'
+          settings:
             HDD_1: 'opensuse-15.2-x86_64-695.1-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - container_image_on_leap15.2_host:
-        testsuite: container-image
-        machine: ppc64le
-        settings:
-            # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
+      - container_image_on_leap15.2_host:
+          testsuite: container-image
+          machine: ppc64le
+          settings:
+              # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.2-ppc64le-GM-kde@ppc64le.qcow2'
             DESKTOP: 'kde'
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        machine: ppc64le
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          machine: ppc64le
+          settings:
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.3-ppc64le-160.3-textmode@ppc64le.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
   aarch64:
     opensuse-15.3-JeOS-for-AArch64-aarch64:
-    - jeos:
-        settings:
-          # Max size isn't that strict
-          EXCLUDE_MODULES: "diskusage"
-    - jeos-extra:
-        settings:
-          # Rails is completely broken, no fix in sight (boo#1174315)
-          EXCLUDE_MODULES: "rails,diskusage"
-    - jeos-container_host:
-        testsuite: null
-        settings:
+      - jeos:
+          settings:
+            # Max size isn't that strict
+            EXCLUDE_MODULES: "diskusage"
+      - jeos-extra:
+          settings:
+            # Rails is completely broken, no fix in sight (boo#1174315)
+            EXCLUDE_MODULES: "rails,diskusage"
+      - jeos-container_host:
+          testsuite: null
+          settings:
             DESKTOP: textmode
             EXTRABOOTPARAMS: quiet
             REGISTRY: 18.156.2.117:5000
@@ -209,9 +212,9 @@ scenarios:
             CONTAINER_RUNTIME: "podman,docker"
             # Max size isn't that strict
             EXCLUDE_MODULES: "diskusage"
-    - jeos-container_image:
-        testsuite: null
-        settings:
+      - jeos-container_image:
+          testsuite: null
+          settings:
             DESKTOP: textmode
             EXTRABOOTPARAMS: quiet
             REGISTRY: 18.156.2.117:5000
@@ -219,38 +222,38 @@ scenarios:
             CONTAINERS_UNTESTED_IMAGES: '1'
             EXCLUDE_MODULES: "diskusage"
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-    - jeos-filesystem:
-        settings:
-          # Max size isn't that strict
-          EXCLUDE_MODULES: "diskusage"
+      - jeos-filesystem:
+          settings:
+            # Max size isn't that strict
+            EXCLUDE_MODULES: "diskusage"
     opensuse-15.3-JeOS-for-RPi-aarch64:
-    - jeos:
-        machine: RPi3
-        settings:
-          PASSWORD: linux
-    - jeos:
-        machine: RPi4
-        settings:
-          PASSWORD: linux
+      - jeos:
+          machine: RPi3
+          settings:
+            PASSWORD: linux
+      - jeos:
+          machine: RPi4
+          settings:
+            PASSWORD: linux
     opensuse-Leap15.3-Rescue-CD-aarch64:
-    - rescue
-    - mediacheck
+      - rescue
+      - mediacheck
     opensuse-Leap15.3-KDE-Live-aarch64:
-    - kde-live
-    - kde-live_installation
-    - kde_live_upgrade_leap_15.0:
-        machine: aarch64
-    - mediacheck
+      - kde-live
+      - kde-live_installation
+      - kde_live_upgrade_leap_15.0:
+          machine: aarch64
+      - mediacheck
     opensuse-Leap15.3-GNOME-Live-aarch64:
-    - gnome-live
-    - mediacheck
+      - gnome-live
+      - mediacheck
     opensuse-Leap15.3-XFCE-Live-aarch64:
-    - xfce-live
-    - mediacheck
+      - xfce-live
+      - mediacheck
     opensuse-15.3-Container-Image-aarch64:
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          settings:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -72,6 +72,8 @@ scenarios:
     opensuse-Leap15.4-JeOS-for-kvm-and-xen-x86_64:
     - jeos:
         machine: 64bit_virtio-2G
+        settings:
+          INFLUXDB_SERVER: '35.158.113.219'
     - jeos:
         machine: uefi_virtio-2G
     - jeos-extra:

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -7,6 +7,9 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #        job_groups/opensuse_leap_15.4_images.yaml         #
 ############################################################
+
+---
+
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -70,150 +73,150 @@ products:
 scenarios:
   x86_64:
     opensuse-Leap15.4-JeOS-for-kvm-and-xen-x86_64:
-    - jeos:
-        machine: 64bit_virtio-2G
-        settings:
-          INFLUXDB_SERVER: '35.158.113.219'
-    - jeos:
-        machine: uefi_virtio-2G
-    - jeos-extra:
-        machine: 64bit_virtio-2G
-        settings:
-          # Completely broken, no fix in sight (boo#1174315)
-          EXCLUDE_MODULES: "rails"
-    - jeos-container_host:
-        machine: 64bit_virtio-2G
-    - jeos-container_image:
-        machine: 64bit_virtio-2G
-        settings:
+      - jeos:
+          machine: 64bit_virtio-2G
+          settings:
+            INFLUXDB_SERVER: '35.158.113.219'
+      - jeos:
+          machine: uefi_virtio-2G
+      - jeos-extra:
+          machine: 64bit_virtio-2G
+          settings:
+            # Completely broken, no fix in sight (boo#1174315)
+            EXCLUDE_MODULES: "rails"
+      - jeos-container_host:
+          machine: 64bit_virtio-2G
+      - jeos-container_image:
+          machine: 64bit_virtio-2G
+          settings:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-    - jeos-filesystem:
-        machine: 64bit_virtio-2G
-    - jeos-ltp-containers:
-        machine: 64bit_virtio
-    - jeos-ltp-cve:
-        machine: 64bit_virtio
-    - jeos-ltp-dio:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls:
-        machine: 64bit_virtio
-    - jeos-ltp-commands:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls-ipc:
-        machine: 64bit_virtio
+      - jeos-filesystem:
+          machine: 64bit_virtio-2G
+      - jeos-ltp-containers:
+          machine: 64bit_virtio
+      - jeos-ltp-cve:
+          machine: 64bit_virtio
+      - jeos-ltp-dio:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls:
+          machine: 64bit_virtio
+      - jeos-ltp-commands:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls-ipc:
+          machine: 64bit_virtio
     opensuse-Leap15.4-GNOME-Live-x86_64:
-    - gnome-live:
-        machine: uefi-2G
-    - gnome-live:
-        machine: 64bit-2G
-    - gnome-live:
-        machine: uefi-usb-2G
-    - gnome-live:
-        machine: USBboot_64-2G
-    - mediacheck:
-        machine: 64bit
+      - gnome-live:
+          machine: uefi-2G
+      - gnome-live:
+          machine: 64bit-2G
+      - gnome-live:
+          machine: uefi-usb-2G
+      - gnome-live:
+          machine: USBboot_64-2G
+      - mediacheck:
+          machine: 64bit
     opensuse-Leap15.4-KDE-Live-x86_64:
-    - kde-live:
-        machine: uefi-usb-2G
-    - kde-live:
-        machine: 64bit-2G
-    - kde-live:
-        machine: USBboot_64-2G
-    - kde-live:
-        machine: uefi-2G
-    - mediacheck:
-        machine: 64bit
-    - kde-live_installation
-    - kde-live-wayland:
-        machine: 64bit_virtio-2G
-    - kde_live_upgrade_leap_42.3
-    - kde_live_upgrade_leap_15.0:
-        machine: 64bit
-        settings:
-          QEMU_VIRTIO_RNG: "0"
-    - kde_live_upgrade_leap_15.2:
-        machine: uefi
-        settings:
-          QEMU_VIRTIO_RNG: "0"
-    - kde_live_upgrade_leap_15.3:
-        machine: 64bit
-        settings:
-          QEMU_VIRTIO_RNG: "0"
+      - kde-live:
+          machine: uefi-usb-2G
+      - kde-live:
+          machine: 64bit-2G
+      - kde-live:
+          machine: USBboot_64-2G
+      - kde-live:
+          machine: uefi-2G
+      - mediacheck:
+          machine: 64bit
+      - kde-live_installation
+      - kde-live-wayland:
+          machine: 64bit_virtio-2G
+      - kde_live_upgrade_leap_42.3
+      - kde_live_upgrade_leap_15.0:
+          machine: 64bit
+          settings:
+            QEMU_VIRTIO_RNG: "0"
+      - kde_live_upgrade_leap_15.2:
+          machine: uefi
+          settings:
+            QEMU_VIRTIO_RNG: "0"
+      - kde_live_upgrade_leap_15.3:
+          machine: 64bit
+          settings:
+            QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.4-Rescue-CD-x86_64:
-    - rescue
-    - rescue:
-        machine: uefi-usb-2G
-    - mediacheck:
-        machine: 64bit
+      - rescue
+      - rescue:
+          machine: uefi-usb-2G
+      - mediacheck:
+          machine: 64bit
     opensuse-Leap15.4-XFCE-Live-x86_64:
-    - xfce-live
-    - xfce-live:
-        machine: uefi-usb-2G
-    - mediacheck
+      - xfce-live
+      - xfce-live:
+          machine: uefi-usb-2G
+      - mediacheck
     opensuse-15.4-Container-Image-x86_64:
-    - container_image_on_centos_host:
-        testsuite: container-image
-        description: 'Container image validation on CentOS 8.2'
-        settings:
+      - container_image_on_centos_host:
+          testsuite: container-image
+          description: 'Container image validation on CentOS 8.2'
+          settings:
             HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
             CONTAINER_RUNTIME: 'podman'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-    - container_image_on_ubuntu_host:
-        testsuite: container-image
-        description: 'Container image validation on Ubuntu 20.04'
-        settings:
+      - container_image_on_ubuntu_host:
+          testsuite: container-image
+          description: 'Container image validation on Ubuntu 20.04'
+          settings:
             HDD_1: 'ubuntu-20.04.1_1.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.2 GM'
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.2 GM'
+          settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-    - container_image_on_leap15.2_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.2 GM'
-        settings:
+      - container_image_on_leap15.2_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.2 GM'
+          settings:
             HDD_1: 'opensuse-15.2-x86_64-695.1-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
             # Product bug:
             # podman-20886.scope: Failed to add PIDs to scope's control group: Permission denied
             # EXCLUDE_MODULES: rootless_podman #uncomment if needed
-    - container_image_on_leap15.2_host:
-        testsuite: container-image
-        machine: ppc64le
-        settings:
-            # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
+      - container_image_on_leap15.2_host:
+          testsuite: container-image
+          machine: ppc64le
+          settings:
+              # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.2-ppc64le-GM-kde@ppc64le.qcow2'
             DESKTOP: 'kde'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        machine: ppc64le
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          machine: ppc64le
+          settings:
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.3-ppc64le-160.3-textmode@ppc64le.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
   aarch64:
     opensuse-15.4-JeOS-for-AArch64-aarch64:
-    - jeos:
-        settings:
-          # Max size isn't that strict
-          EXCLUDE_MODULES: "diskusage"
-    - jeos-extra:
-        settings:
-          # Rails is completely broken, no fix in sight (boo#1174315)
-          EXCLUDE_MODULES: "rails,diskusage"
-    - jeos-container_host:
-        testsuite: null
-        settings:
+      - jeos:
+          settings:
+            # Max size isn't that strict
+            EXCLUDE_MODULES: "diskusage"
+      - jeos-extra:
+          settings:
+            # Rails is completely broken, no fix in sight (boo#1174315)
+            EXCLUDE_MODULES: "rails,diskusage"
+      - jeos-container_host:
+          testsuite: null
+          settings:
             DESKTOP: textmode
             EXTRABOOTPARAMS: quiet
             REGISTRY: 18.156.2.117:5000
@@ -221,9 +224,9 @@ scenarios:
             CONTAINER_RUNTIME: "podman,docker"
             # Max size isn't that strict
             EXCLUDE_MODULES: "diskusage"
-    - jeos-container_image:
-        testsuite: null
-        settings:
+      - jeos-container_image:
+          testsuite: null
+          settings:
             DESKTOP: textmode
             EXTRABOOTPARAMS: quiet
             REGISTRY: 18.156.2.117:5000
@@ -231,45 +234,45 @@ scenarios:
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
             EXCLUDE_MODULES: "diskusage"
-    - jeos-filesystem:
-        settings:
+      - jeos-filesystem:
+          settings:
             EXCLUDE_MODULES: "diskusage"
-    - jeos-ltp-containers
-    - jeos-ltp-cve
-    - jeos-ltp-dio
-    - jeos-ltp-syscalls
-    - jeos-ltp-commands
-    - jeos-ltp-syscalls-ipc
+      - jeos-ltp-containers
+      - jeos-ltp-cve
+      - jeos-ltp-dio
+      - jeos-ltp-syscalls
+      - jeos-ltp-commands
+      - jeos-ltp-syscalls-ipc
     opensuse-15.4-JeOS-for-RPi-aarch64:
-    - jeos:
-        machine: RPi3
-        settings:
-          PASSWORD: linux
-    - jeos:
-        machine: RPi4
-        settings:
-          PASSWORD: linux
+      - jeos:
+          machine: RPi3
+          settings:
+            PASSWORD: linux
+      - jeos:
+          machine: RPi4
+          settings:
+            PASSWORD: linux
     opensuse-Leap15.4-Rescue-CD-aarch64:
-    - rescue
-    - mediacheck
+      - rescue
+      - mediacheck
     opensuse-Leap15.4-KDE-Live-aarch64:
-    - kde-live
-    - kde-live_installation
-    - kde_live_upgrade_leap_15.0:
-        machine: aarch64
-    - kde_live_upgrade_leap_15.3:
-        machine: aarch64
-    - mediacheck
+      - kde-live
+      - kde-live_installation
+      - kde_live_upgrade_leap_15.0:
+          machine: aarch64
+      - kde_live_upgrade_leap_15.3:
+          machine: aarch64
+      - mediacheck
     opensuse-Leap15.4-GNOME-Live-aarch64:
-    - gnome-live
-    - mediacheck
+      - gnome-live
+      - mediacheck
     opensuse-Leap15.4-XFCE-Live-aarch64:
-    - xfce-live
-    - mediacheck
+      - xfce-live
+      - mediacheck
     opensuse-15.4-Container-Image-aarch64:
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          settings:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -985,6 +985,8 @@ scenarios:
       - jeos:
           machine: 64bit_virtio
           priority: 48
+          settings:
+            INFLUXDB_SERVER: '35.158.113.219'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -7,7 +7,9 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #           job_groups/opensuse_tumbleweed.yaml            #
 ############################################################
+
 ---
+
 defaults:
   i586:
     machine: 32bit
@@ -372,8 +374,8 @@ scenarios:
             NUMDISKS: '4'
             YAML_SCHEDULE: schedule/yast/opensuse/autoyast/autoyast_multi_btrfs.yaml
           description: AutoYaST installation with multi-device Btrfs. The setup containing 4 hds using two
-                       multidevice btrfs, one mounted on / and one mounted on /test. Combines partition-less
-                       disk and disk with partition, also includes an encrypted disk.
+            multidevice btrfs, one mounted on / and one mounted on /test. Combines partition-less
+            disk and disk with partition, also includes an encrypted disk.
           testsuite: null
           machine: 64bit
       - autoyast_rules_and_classes:
@@ -452,8 +454,8 @@ scenarios:
       - system_performance
       - select_disk:
           description: 'Maintainer: riafarov, mloviska Test the selection of "first" disk with the guided
-                        setup in partitioning. This is also used as a prerequisite for real hardware tests
-                        to select the right disk for installation and not a "random" one.'
+            setup in partitioning. This is also used as a prerequisite for real hardware tests
+            to select the right disk for installation and not a "random" one.'
           settings:
             NUMDISKS: '2'
             YAML_SCHEDULE: schedule/yast/opensuse/select_disk/select_disk.yaml

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -7,7 +7,9 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #       job_groups/opensuse_tumbleweed_aarch64.yaml        #
 ############################################################
+
 ---
+
 defaults:
   aarch64:
     machine: aarch64

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -517,6 +517,8 @@ scenarios:
       - jeos:
           machine: aarch64-HD24G
           priority: 45
+          settings:
+            INFLUXDB_SERVER: '35.158.113.219'
       - jeos-extra:
           machine: aarch64-HD24G
           priority: 45


### PR DESCRIPTION
JeOS jobs have a module that posts some information to a DB
when this variable is defined. We define it only in 1 job for
each flavor.