### PR TITLE
Change booted image only for Leap testing

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -224,9 +224,11 @@ scenarios:
       - zdup-Leap-15.2-gnome:
           settings:
             QEMU_VIRTIO_RNG: "0"
+            +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-gnome@%MACHINE%.qcow2"
       - zdup-Leap-15.2-kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+            +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-kde@%MACHINE%.qcow2"
       - upgrade_Leap_42.3_gnome:
           machine: 64bit
       - upgrade_Leap_42.3_kde:
@@ -417,9 +419,11 @@ scenarios:
       - upgrade_Leap_15.2_gnome:
           settings:
             QEMU_VIRTIO_RNG: "0"
+            +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-gnome@%MACHINE%.qcow2"
       - upgrade_Leap_15.2_kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+            +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-kde@%MACHINE%.qcow2"
       - upgrade_Leap_15.2_cryptlvm:
           machine: uefi
           settings:


### PR DESCRIPTION
I have updated the Leap15.2 assets for `zdup-Leap-15.2-{gnome,kde}`
scenarios. Unfortunately, I have missed this test suite is used in
TW@aarch64.

- [opensuse-15.2-aarch64-GM-Updated-gnome@aarch64.qcow2 gone?](https://progress.opensuse.org/issues/111467)