### PR TITLE
yamllint: Disable truthy rule

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,3 +2,4 @@ extends: default
 rules:
   line-length:
     max: 190
+  truthy: disable


### PR DESCRIPTION
This is relevant for YAML 1.1 files where "yes" has a boolean meaning.
We don't need it for our files as we are using YAML 1.2

I saw a warning in
https://github.com/os-autoinst/opensuse-jobgroups/pull/139/files