### PR TITLE
Leap15.3: whitelist libpeas-loader-python orphan

### DIFF
--- a/job_groups/opensuse_leap_15.3_backports.yaml
+++ b/job_groups/opensuse_leap_15.3_backports.yaml
@@ -7,6 +7,7 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #       job_groups/opensuse_leap_15.3_backports.yaml       #
 ############################################################
+---
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -19,22 +20,24 @@ products:
 scenarios:
   x86_64:
     opensuse-15.3-DVD-Backports-x86_64:
-    - textmode:
-        machine: 64bit
-    - kde
-    - gnome:
-        machine: uefi
-        settings:
-          QEMUVGA: cirrus
-    - gnome:
-        machine: 64bit-2G
-        settings:
-          QEMUVGA: cirrus
-    - cryptlvm:
-        settings:
-          YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
-    - install_with_updates_gnome:
-        settings:
-          QEMUVGA: cirrus
-    - install_with_updates_kde:
-        machine: uefi-2G
+      - textmode:
+          machine: 64bit
+      - kde:
+          settings:
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - gnome:
+          machine: [uefi, 64bit-2G]
+          settings:
+            QEMUVGA: cirrus
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - cryptlvm:
+          settings:
+            YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+      - install_with_updates_gnome:
+          settings:
+            QEMUVGA: cirrus
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - install_with_updates_kde:
+          machine: uefi-2G
+          settings:
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python

--- a/job_groups/opensuse_leap_15.3_updates.yaml
+++ b/job_groups/opensuse_leap_15.3_updates.yaml
@@ -7,6 +7,7 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #        job_groups/opensuse_leap_15.3_updates.yaml        #
 ############################################################
+---
 defaults:
   x86_64:
     machine: 64bit
@@ -19,45 +20,45 @@ products:
 scenarios:
   x86_64:
     opensuse-15.3-DVD-Updates-x86_64:
-    - textmode:
-        machine: 64bit
-    - gnome:
-        machine: uefi
-        settings:
-          QEMUVGA: cirrus
-    - gnome:
-        machine: 64bit-2G
-        settings:
-          QEMUVGA: cirrus
-    - cryptlvm:
-        settings:
-          YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
-    - install_with_updates_gnome:
-        machine: 64bit-2G
-        settings:
-          QEMUVGA: cirrus
-    - install_with_updates_kde:
-        machine: uefi-2G
-        # poo#95137
-        settings:
-          EXCLUDE_MODULES: 'kontact'
-    - create_hdd_gnome:
-        machine: 64bit
-    - create_hdd_gnome:
-        machine: uefi
-    - create_hdd_kde:
-        machine: uefi
-    - create_hdd_kde:
-        machine: 64bit
-    - create_hdd_gnome_libyui
-    - create_hdd_textmode
-    - extra_tests_on_kde
-    - gnuhealth
-    - toolkits
-    - openqa_bootstrap
-    # poo#107242
-    # - openqa_bootstrap_container
-    - yast2_firstboot
-    - extra_tests_misc
-    - kde
-
+      - textmode:
+          machine: 64bit
+      - gnome:
+          machine: [uefi, 64bit-2G]
+          settings:
+            QEMUVGA: cirrus
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - cryptlvm:
+          settings:
+            YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+      - install_with_updates_gnome:
+          machine: 64bit-2G
+          settings:
+            QEMUVGA: cirrus
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - install_with_updates_kde:
+          machine: uefi-2G
+          # poo#95137
+          settings:
+            EXCLUDE_MODULES: 'kontact'
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+      - create_hdd_gnome:
+          machine: 64bit
+      - create_hdd_gnome:
+          machine: uefi
+      - create_hdd_kde:
+          machine: uefi
+      - create_hdd_kde:
+          machine: 64bit
+      - create_hdd_gnome_libyui
+      - create_hdd_textmode
+      - extra_tests_on_kde
+      - gnuhealth
+      - toolkits
+      - openqa_bootstrap
+      # poo#107242
+      # - openqa_bootstrap_container
+      - yast2_firstboot
+      - extra_tests_misc
+      - kde:
+          settings:
+            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python


### PR DESCRIPTION
According to https://bugzilla.suse.com/show_bug.cgi?id=1199442, package
 *libpeas-loader-python* has been dropped.