### PR TITLE
Containers: use new Ubuntu 22.04 HDD

### DIFF
--- a/job_groups/opensuse_leap_15.2_images.yaml
+++ b/job_groups/opensuse_leap_15.2_images.yaml
@@ -7,6 +7,9 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #        job_groups/opensuse_leap_15.2_images.yaml         #
 ############################################################
+
+---
+
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -35,83 +38,83 @@ products:
 scenarios:
   x86_64:
     opensuse-15.2-GNOME-Live-x86_64:
-    - gnome-live:
-        machine: uefi-2G
-    - gnome-live:
-        machine: 64bit-2G
-    - gnome-live:
-        machine: uefi-usb-2G
-    - gnome-live:
-        machine: USBboot_64-2G
-    - mediacheck:
-        machine: 64bit
+      - gnome-live:
+          machine: uefi-2G
+      - gnome-live:
+          machine: 64bit-2G
+      - gnome-live:
+          machine: uefi-usb-2G
+      - gnome-live:
+          machine: USBboot_64-2G
+      - mediacheck:
+          machine: 64bit
     opensuse-15.2-JeOS-for-kvm-and-xen-x86_64:
-    - jeos:
-        machine: 64bit_virtio-2G
-    - jeos:
-        machine: uefi_virtio-2G
-    - jeos-extra:
-        machine: 64bit_virtio-2G
-        settings:
-          # Completely broken, no fix in sight (boo#1174315)
-          EXCLUDE_MODULES: "rails"
-    - jeos-container_host:
-        machine: 64bit_virtio-2G
-    - jeos-container_image:
-        machine: 64bit_virtio-2G
-    - jeos-filesystem:
-        machine: 64bit_virtio-2G
-    - jeos-ltp-containers:
-        machine: 64bit_virtio
-    - jeos-ltp-cve:
-        machine: 64bit_virtio
-    - jeos-ltp-dio:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls:
-        machine: 64bit_virtio
-    - jeos-ltp-commands:
-        machine: 64bit_virtio
-    - jeos-ltp-syscalls-ipc:
-        machine: 64bit_virtio
+      - jeos:
+          machine: 64bit_virtio-2G
+      - jeos:
+          machine: uefi_virtio-2G
+      - jeos-extra:
+          machine: 64bit_virtio-2G
+          settings:
+            # Completely broken, no fix in sight (boo#1174315)
+            EXCLUDE_MODULES: "rails"
+      - jeos-container_host:
+          machine: 64bit_virtio-2G
+      - jeos-container_image:
+          machine: 64bit_virtio-2G
+      - jeos-filesystem:
+          machine: 64bit_virtio-2G
+      - jeos-ltp-containers:
+          machine: 64bit_virtio
+      - jeos-ltp-cve:
+          machine: 64bit_virtio
+      - jeos-ltp-dio:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls:
+          machine: 64bit_virtio
+      - jeos-ltp-commands:
+          machine: 64bit_virtio
+      - jeos-ltp-syscalls-ipc:
+          machine: 64bit_virtio
     opensuse-15.2-KDE-Live-x86_64:
-    - kde-live:
-        machine: uefi-usb-2G
-    - kde-live:
-        machine: 64bit-2G
-    - kde-live:
-        machine: USBboot_64-2G
-    - kde-live:
-        machine: uefi-2G
-    - mediacheck:
-        machine: 64bit
-    - kde-live_installation
-    - kde-live-wayland:
-        machine: 64bit_virtio-2G
-    - kde_live_upgrade_leap_42.3
-    - kde_live_upgrade_leap_15.0:
-        machine: 64bit
+      - kde-live:
+          machine: uefi-usb-2G
+      - kde-live:
+          machine: 64bit-2G
+      - kde-live:
+          machine: USBboot_64-2G
+      - kde-live:
+          machine: uefi-2G
+      - mediacheck:
+          machine: 64bit
+      - kde-live_installation
+      - kde-live-wayland:
+          machine: 64bit_virtio-2G
+      - kde_live_upgrade_leap_42.3
+      - kde_live_upgrade_leap_15.0:
+          machine: 64bit
     opensuse-15.2-Rescue-CD-x86_64:
-    - rescue
+      - rescue
     opensuse-Leap15.2-Container-Image-x86_64:
-    - container_image_on_centos_host:
-        testsuite: container-image
-        description: 'Container image validation on CentOS 8.2'
-        settings:
+      - container_image_on_centos_host:
+          testsuite: container-image
+          description: 'Container image validation on CentOS 8.2'
+          settings:
             HDD_1: 'centOS-8.2.2004-x86_64-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
-    - container_image_on_ubuntu_host:
-        testsuite: container-image
-        description: 'Container image validation on Ubuntu 20.04'
-        settings:
-            HDD_1: 'ubuntu-20.04.1_1.qcow2'
+      - container_image_on_ubuntu_host:
+          testsuite: container-image
+          description: 'Container image validation on Ubuntu 22.04'
+          settings:
+            HDD_1: 'ubuntu-22.04.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
-    - container_image_on_leap15.3_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.2 GM'
-        settings:
+      - container_image_on_leap15.3_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.2 GM'
+          settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
-    - container_image_on_leap15.2_host:
-        testsuite: container-image
-        description: 'Container image validation on Leap 15.2 GM'
-        settings:
+      - container_image_on_leap15.2_host:
+          testsuite: container-image
+          description: 'Container image validation on Leap 15.2 GM'
+          settings:
             HDD_1: 'opensuse-15.2-x86_64-695.1-textmode@64bit.qcow2'

--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -158,9 +158,9 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
       - container_image_on_ubuntu_host:
           testsuite: container-image
-          description: 'Container image validation on Ubuntu 20.04'
+          description: 'Container image validation on Ubuntu 22.04'
           settings:
-            HDD_1: 'ubuntu-20.04.1_1.qcow2'
+            HDD_1: 'ubuntu-22.04.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
@@ -181,7 +181,7 @@ scenarios:
           testsuite: container-image
           machine: ppc64le
           settings:
-              # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
+            # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.2-ppc64le-GM-kde@ppc64le.qcow2'
             DESKTOP: 'kde'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -166,9 +166,9 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
       - container_image_on_ubuntu_host:
           testsuite: container-image
-          description: 'Container image validation on Ubuntu 20.04'
+          description: 'Container image validation on Ubuntu 22.04'
           settings:
-            HDD_1: 'ubuntu-20.04.1_1.qcow2'
+            HDD_1: 'ubuntu-22.04.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'
@@ -192,7 +192,7 @@ scenarios:
           testsuite: container-image
           machine: ppc64le
           settings:
-              # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
+            # we force the ppc64le machine and ARCH here because OBS sync doesn't trigger ppc64le jobs
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.2-ppc64le-GM-kde@ppc64le.qcow2'
             DESKTOP: 'kde'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1120,7 +1120,7 @@ scenarios:
             VIDEOMODE: text
             KEEP_GRUB_TIMEOUT: '1'
             BOOT_HDD_IMAGE: '1'
-            HDD_1: 'ubuntu-20.04.1_1.qcow2'
+            HDD_1: 'ubuntu-22.04.qcow2'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed'
             CONTAINERS_NO_SUSE_OS: "1"


### PR DESCRIPTION
The image we have for Ubuntu 20.04 lost the support for podman and
buildah containers. It happened first in OSD and it was switched to
22.04 showing good results.
Now, podman and buildah are part of Ubuntu repos instead of Kubic
repos as it was for 20.04

Related ticket: https://progress.opensuse.org/issues/111485