### PR TITLE
Fix job group YAML path for opensuse_jump

### DIFF
--- a/job_groups/opensuse_jump.yaml
+++ b/job_groups/opensuse_jump.yaml
@@ -146,7 +146,7 @@ scenarios:
       - extra_tests_in_textmode
       - extra_tests_textmode_containers:
           settings:
-            YAML_SCHEDULE: schedule/containers/extra_tests_textmode_containers.yaml
+            CONTAINER_RUNTIME: docker
       - extra_tests_ai_ml
       - zdup-Leap-42.2-gnome:
           machine: 64bit_cirrus
@@ -370,7 +370,7 @@ scenarios:
       - extra_tests_in_textmode
       - extra_tests_textmode_containers:
           settings:
-            YAML_SCHEDULE: schedule/containers/extra_tests_textmode_containers.yaml
+            CONTAINER_RUNTIME: docker
       - extra_tests_ai_ml
       - autoyast_minimal
       - package-dependency:
@@ -454,7 +454,7 @@ scenarios:
       - extra_tests_filesystem
       - extra_tests_textmode_containers:
           settings:
-            YAML_SCHEDULE: schedule/containers/extra_tests_textmode_containers.yaml
+            CONTAINER_RUNTIME: docker
       - yast2_ncurses
       - extra_tests_dracut
     opensuse-Jump-15.2-NET-ppc64le:


### PR DESCRIPTION
As of https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/9441a7e9876197923947524e51fa06b2f3c15e03
there is not valid reference anymore.