### PR TITLE
Whitelist gtk2 package in leap15.3 (KDE)

### DIFF
--- a/job_groups/opensuse_leap_15.3_backports.yaml
+++ b/job_groups/opensuse_leap_15.3_backports.yaml
@@ -24,7 +24,7 @@ scenarios:
           machine: 64bit
       - kde:
           settings:
-            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+            ZYPPER_WHITELISTED_ORPHANS: libreoffice-gtk2
       - gnome:
           machine: [uefi, 64bit-2G]
           settings:
@@ -40,4 +40,4 @@ scenarios:
       - install_with_updates_kde:
           machine: uefi-2G
           settings:
-            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+            ZYPPER_WHITELISTED_ORPHANS: libreoffice-gtk2

--- a/job_groups/opensuse_leap_15.3_updates.yaml
+++ b/job_groups/opensuse_leap_15.3_updates.yaml
@@ -40,7 +40,7 @@ scenarios:
           # poo#95137
           settings:
             EXCLUDE_MODULES: 'kontact'
-            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+            ZYPPER_WHITELISTED_ORPHANS: libreoffice-gtk2
       - create_hdd_gnome:
           machine: 64bit
       - create_hdd_gnome:
@@ -61,4 +61,4 @@ scenarios:
       - extra_tests_misc
       - kde:
           settings:
-            ZYPPER_WHITELISTED_ORPHANS: libpeas-loader-python
+            ZYPPER_WHITELISTED_ORPHANS: libreoffice-gtk2


### PR DESCRIPTION
Orphaned package *libreoffice-gtk2* reported in https://bugzilla.suse.com/show_bug.cgi?id=1199442
In order to not block release process, let's whitelist the package