### PR TITLE
Add autoyast_create_hdd_uefi jobs to TW

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -946,6 +946,16 @@ scenarios:
             START_AFTER_TEST: create_hdd_gnome_encrypt_separate_boot
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%_encrypt_separate_boot.qcow2'
             YAML_SCHEDULE: schedule/security/luks1_decrypt_ssh_server.yaml
+      - autoyast_create_hdd_gnome_uefi:
+          testsuite: create_hdd_desktop_ay_uefi
+          machine: uefi
+          settings:
+            DESKTOP: gnome
+      - autoyast_create_hdd_textmode_uefi:
+          testsuite: create_hdd_desktop_ay_uefi
+          machine: uefi
+          settings:
+            DESKTOP: textmode
     opensuse-Tumbleweed-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi


### PR DESCRIPTION
Add `autoyast_create_hdd_gnome_uefi` and
`autoyast_create_hdd_textmode_uefi` to openSUSE Tumbleweed
job group, the generated qcow2 images are used for security tests.

Related ticket: 
  - [poo#111281](https://progress.opensuse.org/issues/111281)
  - [poo#111380](https://progress.opensuse.org/issues/111380)

The related PR of os-autoinst-distri-opensuse: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/14946