### PR TITLE
tumbleweed_kernel: aarch64: ppc64le: Add xfstests on btrfs

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -113,6 +113,8 @@ scenarios:
       - nfs_cthon04-nfs4
       - nfs_pynfs_nfs40_all
       - nfs_pynfs_nfs41_all
+      - create_hdd_xfstests
+      - xfstests_btrfs-btrfs-001-050
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
       - extra_tests_kernel
@@ -195,6 +197,8 @@ scenarios:
       - nfs_cthon04-nfs4
       - nfs_pynfs_nfs40_all
       - nfs_pynfs_nfs41_all
+      - create_hdd_xfstests
+      - xfstests_btrfs-btrfs-001-050
   x86_64:
     opensuse-Tumbleweed-DVD-x86_64:
       - extra_tests_kernel


### PR DESCRIPTION
xfstests on btrfs are relatively stable (only btrfs-029 fails on intel).

Not adding xfstests on btrfs, currently all of them failing due missing
user and group:

Setup chown: warning: . should be :: 4.4
chown: warning: . should be :: 4.4
.chown: invalid user: daemon.sys
chown: invalid user: daemon.sys
.chown: warning: . should be :: bin.bin
chown: warning: . should be :: bin.bin
.chown: invalid user: 4.sys
chown: invalid user: 4.sys