### PR TITLE
Add official repos for zdup test cases

### DIFF
--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -8,6 +8,15 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #        job_groups/opensuse_leap_15.4_updates.yaml        #
 ############################################################
+
+.zdup_settings: &zdup
+  +ISO: "openSUSE-Leap-15.4-DVD-x86_64.iso"
+  ZDUPREPOS: "http://download.opensuse.org/distribution/leap/15.4/repo/oss/,
+              http://download.opensuse.org/update/leap/15.4/oss/,
+              http://download.opensuse.org/update/leap/15.4/backports/,
+              http://download.opensuse.org/update/leap/15.4/sle/
+              "
+
 defaults:
   x86_64:
     machine: 64bit
@@ -63,15 +72,19 @@ scenarios:
       - kde
       - zdup-Leap-15.2-gnome:
           settings:
+            <<: *zdup
             QEMU_VIRTIO_RNG: "0"
             +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-gnome@%MACHINE%.qcow2"
       - zdup-Leap-15.2-kde:
           settings:
+            <<: *zdup
             QEMU_VIRTIO_RNG: "0"
             +HDD_1: "%DISTRI%-15.2-%ARCH%-GM-Updated-kde@%MACHINE%.qcow2"
       - zdup-Leap-15.3-gnome:
           settings:
+            <<: *zdup
             QEMU_VIRTIO_RNG: "0"
       - zdup-Leap-15.3-kde:
           settings:
+            <<: *zdup
             QEMU_VIRTIO_RNG: "0"


### PR DESCRIPTION
As `ISO` definition is empty in `zdup-Leap` testcases and the `ttm`
scheduler does not include it either, we should define it in the jobgroup
as Updates testing is specific. Example of a job setting pushed by `ttm`

```
ARCH	x86_64
BUILD	20220608-3
DISTRI	opensuse
FLAVOR	DVD-Updates
OS_TEST_ISSUES
REPOHASH	e9c681458523865d92fbbf81e8bd1d07
VERSION	15.4
_OBSOLETE	1
```

Adding the ISO is only to avoid failures as we do not have set value of
`SUSEMIRROR`. Later only the official `download.opensuse.org` repos should
be added in order to proceed with the migration.

VR: [Leap15.2, ISO + ZDUPREPOS](http://kepler.suse.cz/tests/17289#)
VR: [Leap15.2, ISO](http://kepler.suse.cz/tests/17284#step/sshd/28)