### PR TITLE
Add LTP IMA tests under JeOS

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -100,6 +100,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-dio:
           machine: 64bit_virtio
+      - jeos-ltp-ima:
+          machine: 64bit_virtio
       - jeos-ltp-syscalls:
           machine: 64bit_virtio
       - jeos-ltp-syscalls-ipc:

--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -92,6 +92,8 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
       - jeos-filesystem:
           machine: 64bit_virtio-2G
+      - jeos-ltp-commands:
+          machine: 64bit_virtio
       - jeos-ltp-containers:
           machine: 64bit_virtio
       - jeos-ltp-cve:
@@ -99,8 +101,6 @@ scenarios:
       - jeos-ltp-dio:
           machine: 64bit_virtio
       - jeos-ltp-syscalls:
-          machine: 64bit_virtio
-      - jeos-ltp-commands:
           machine: 64bit_virtio
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -92,6 +92,8 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
       - jeos-filesystem:
           machine: 64bit_virtio-2G
+      - jeos-ltp-commands:
+          machine: 64bit_virtio
       - jeos-ltp-containers:
           machine: 64bit_virtio
       - jeos-ltp-cve:
@@ -99,8 +101,6 @@ scenarios:
       - jeos-ltp-dio:
           machine: 64bit_virtio
       - jeos-ltp-syscalls:
-          machine: 64bit_virtio
-      - jeos-ltp-commands:
           machine: 64bit_virtio
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -998,6 +998,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-fips:
           machine: 64bit_virtio
+      - jeos-ltp-commands:
+          machine: uefi_virtio-2G
       - jeos-ltp-containers:
           machine: uefi_virtio-2G
       - jeos-ltp-cve:
@@ -1005,8 +1007,6 @@ scenarios:
       - jeos-ltp-dio:
           machine: uefi_virtio-2G
       - jeos-ltp-syscalls:
-          machine: uefi_virtio-2G
-      - jeos-ltp-commands:
           machine: uefi_virtio-2G
       - jeos-ltp-syscalls-ipc:
           machine: uefi_virtio-2G


### PR DESCRIPTION
Verification run
* opensuse-15.3-JeOS-for-kvm-and-xen-x86_64
http://quasar.suse.cz/tests/46

Tests in development (not part of this PR, but with this proof it obviously could be):
* opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20220614-jeos-ltp-ima@uefi_virtio-2G
https://openqa.opensuse.org/tests/2418187

<s>
Unrelated failures, but remove and first test in the development group:

* opensuse-15.4-JeOS-for-kvm-and-xen-x86_64
http://quasar.suse.cz/tests/50
* Tumbleweed-JeOS-for-kvm-and-xen-x86_64
http://quasar.suse.cz/tests/49
</s>