### PR TITLE
Update InfluxDB IP

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -76,7 +76,7 @@ scenarios:
       - jeos:
           machine: 64bit_virtio-2G
           settings:
-            INFLUXDB_SERVER: '35.158.113.219'
+            INFLUXDB_SERVER: '18.156.198.190'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -76,7 +76,7 @@ scenarios:
       - jeos:
           machine: 64bit_virtio-2G
           settings:
-            INFLUXDB_SERVER: '35.158.113.219'
+            INFLUXDB_SERVER: '18.156.198.190'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -979,7 +979,7 @@ scenarios:
           machine: 64bit_virtio
           priority: 48
           settings:
-            INFLUXDB_SERVER: '35.158.113.219'
+            INFLUXDB_SERVER: '18.156.198.190'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -501,7 +501,7 @@ scenarios:
           machine: aarch64-HD24G
           priority: 45
           settings:
-            INFLUXDB_SERVER: '35.158.113.219'
+            INFLUXDB_SERVER: '18.156.198.190'
       - jeos-extra:
           machine: aarch64-HD24G
           priority: 45


### PR DESCRIPTION
The IP we are using today belongs to a VM that will be shut down soon. A new VM has been created with new IP.

VR: https://openqa.opensuse.org/tests/2417112#