### PR TITLE
Add libserf & ecryptfs & scap_workbench to prod group

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -461,6 +461,8 @@ scenarios:
           testsuite: null
       - apparmor
       - scap_workbench
+      - libserf
+      - ecryptfs
       - lvm-encrypt-separate-boot:
           machine: 64bit
       - lvm-full-encrypt

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -338,6 +338,9 @@ scenarios:
       - system_performance
       - system_check
       - apparmor
+      - scap_workbench
+      - libserf
+      - ecryptfs
       - security_grub_auth
       - zdup-Leap-15.2-gnome
       - openscap


### PR DESCRIPTION
Add `libserf` and `ecryptfs` to x86_64 and aarch64 production groups,
and add `scap_workbench` to aarch64 production job group.

Verification runs:

libserf:
  - aarch64: https://openqa.opensuse.org/tests/2418471#
  - x86_64: https://openqa.opensuse.org/tests/2418406#

ecryptfs:
  - aarch64: https://openqa.opensuse.org/tests/2418470#
  - x86_64: https://openqa.opensuse.org/tests/2417858#

scap_workbench:
  -  aarch64: https://openqa.opensuse.org/tests/2415639#
  p.s. `scap_workbench` is already in TW x86_64 prod group.