### PR TITLE
Renamed WSL_INSTALL_FROM from all previous TW tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1215,7 +1215,7 @@ scenarios:
             VNC_STALL_THRESHOLD: '10'
             VNC_TYPING_LIMIT: '15'
             QEMU_ENABLE_SMBD: '1'
-            INSTALL_FROM: 'build'
+            WSL_INSTALL_FROM: 'build'
       - wsl-main:
           testsuite: null
           machine: uefi_win


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/113051