### PR TITLE
Containers: add variable to push image data to DataBase

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -194,6 +194,7 @@ scenarios:
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.3-ppc64le-160.3-textmode@ppc64le.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
+            IMAGE_STORE_DATA: '1'
   aarch64:
     opensuse-15.3-JeOS-for-AArch64-aarch64:
       - jeos:
@@ -259,3 +260,4 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
+            IMAGE_STORE_DATA: '1'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -204,6 +204,7 @@ scenarios:
             +ARCH: 'ppc64le'
             HDD_1: 'opensuse-15.3-ppc64le-160.3-textmode@ppc64le.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
+            IMAGE_STORE_DATA: '1'
   aarch64:
     opensuse-15.4-JeOS-for-AArch64-aarch64:
       - jeos:
@@ -276,3 +277,4 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
+            IMAGE_STORE_DATA: '1'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -322,6 +322,7 @@ scenarios:
             CONTAINER_RUNTIME: 'docker,podman'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
+            IMAGE_STORE_DATA: '1'
       - extra_tests_ai_ml
       - yast_no_self_update
       - gnome-gdm:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -248,6 +248,7 @@ scenarios:
           settings:
             CONTAINER_RUNTIME: 'docker,podman'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            IMAGE_STORE_DATA: '1'
       - create_hdd_textmode_secureboot:
           testsuite: null
           machine: aarch64-secureboot-opensuse-key


### PR DESCRIPTION
With this variable, we will allow the code to push the size of the
container image to a database to display it later on with some
graphs.
In the future, we might extend the functionality to push more info.

Related: https://hackweek.opensuse.org/projects/tool-to-collect-relevant-data-from-images-and-containers-tested-in-openqa