### PR TITLE
openqa.yaml: Remove obsolete retry

### DIFF
--- a/job_groups/openqa.yaml
+++ b/job_groups/openqa.yaml
@@ -48,7 +48,6 @@ scenarios:
           settings:
             OPENQA_CONTAINERS: '1'
             OPENQA_FROM_GIT: '1'  # see: main.pm, avoid load_osautoinst_tests
-            RETRY: 2:https://progress.opensuse.org/issues/108665
           description: >-
             Maintainer: okurz@suse.de Test for running openQA itself from containers.
             To be used with "openqa" distri.

--- a/job_groups/openqa.yaml
+++ b/job_groups/openqa.yaml
@@ -32,7 +32,6 @@ scenarios:
             PUBLISH_HDD_1: 'opensuse-Tumbleweed-%ARCH%@%MACHINE%-%BUILD%.qcow2'
             PUBLISH_PFLASH_VARS: 'opensuse-Tumbleweed-%ARCH%@%MACHINE%-%BUILD%-uefi-vars.qcow2'
             PYTHON: '1'
-            RETRY: 3:https://progress.opensuse.org/issues/112232
           description: >-
             Maintainer: okurz@suse.de Test for installation of openQA itself.
             To be used with "openqa" distri. Publishes an qcow2 image including the openQA installation


### PR DESCRIPTION
Retrying is now better handled within openQA test code

Related progress issue: https://progress.opensuse.org/issues/112232