### PR TITLE
Move yast2-apparmor from devel to prod

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -279,6 +279,7 @@ scenarios:
       - yast2_nfs_v4_client
       - yast2_ui_devel
       - yast2_users
+      - yast2_apparmor
       - extra_tests_gnome
       - create_hdd_xfce:
           priority: 46


### PR DESCRIPTION
Test has been deleted from 'Development Tumbleweed' and, with this PR, moved to prod.

https://progress.opensuse.org/issues/112979