### PR TITLE
Add kubectl to Tumbleweed

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -317,6 +317,10 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'helm'
+      - containers_host_kubectl:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIME: 'kubectl'
       - containers_image:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Add the kubectl test run to Tumbleweed x86_64.

The test run is in [Development/Tumbleweed](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20220719&groupid=38&test=containers_host_kubectl) since 2 successful test runs.