### PR TITLE
opensuse_tumbleweed.yaml: Give create_hdd_tumbleweed* more RAM

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1157,9 +1157,13 @@ scenarios:
           settings:
             QEMU_VIRTIO_RNG: "0"
       - create_hdd_minimalx
-      - create_hdd_tumbleweed
+      - create_hdd_tumbleweed:
+          # Workaround for boo#1200753
+          machine: 64bit-3G
       - zdup_tw2twnext_gnome
-      - create_hdd_tumbleweed_kde
+      - create_hdd_tumbleweed_kde:
+          # Workaround for boo#1200753
+          machine: 64bit-3G
       - zdup_tw2twnext_kde
       - otherDE_enlightenment
       - otherDE_lxqt


### PR DESCRIPTION
The installation initrd needs more memory to fit, otherwise random corruption
occurs (boo#1200753). Switch from 1.5GiB to 2GiB.

For some reason only happens on Leap 15.4 workers (ow7).

Before: https://openqa.opensuse.org/tests/2479950
After: https://openqa.opensuse.org/tests/2480405 (clone with `QEMURAM=2048 WORKER_CLASS=openqaworker7`)