### PR TITLE
opensuse_tumbleweed: Don't restrict wsl2-main to openqaworker1

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1247,4 +1247,3 @@ scenarios:
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
             QEMUCPUS: '2'
-            WORKER_CLASS: 'openqaworker1'


### PR DESCRIPTION
Apparently it works on other workers just fine.