### PR TITLE
win version

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -744,6 +744,7 @@ scenarios:
             BOOTFROM: c
             DESKTOP: gnome
             HDD_1: windows-10-x86_64-20H2@64bit_win.qcow2
+            WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
             # poo#101620


### PR DESCRIPTION
Follow-up to https://github.com/os-autoinst/opensuse-jobgroups/pull/183

- Add WIN_VERSION: 10 setting to Windows system tests

One test was missed to receive the WIN_VERSION: 10 setting