### PR TITLE
Switch remaining Tumbleweed win10 tests to 21H2

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -689,13 +689,12 @@ scenarios:
       - desktopapps-remote-desktop-xrdp-server1:
           settings:
             BOOTFROM: c
-            HDD_1: windows-10-x86_64-20H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
             NLA: '1'
-            # poo#101620
-            QEMUMACHINE: 'pc-i440fx-4.2'
+            QEMUMACHINE: 'q35'
             REGRESSION: remote
             REMOTE_DESKTOP_TYPE: win_server
             WORKER_CLASS: tap
@@ -721,13 +720,12 @@ scenarios:
       - desktopapps-remote-desktop-xrdp-server2:
           settings:
             BOOTFROM: c
-            HDD_1: windows-10-x86_64-20H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
             NLA: '0'
-            # poo#101620
-            QEMUMACHINE: 'pc-i440fx-4.2'
+            QEMUMACHINE: 'q35'
             REGRESSION: remote
             REMOTE_DESKTOP_TYPE: win_server
             WORKER_CLASS: tap
@@ -743,12 +741,11 @@ scenarios:
           settings:
             BOOTFROM: c
             DESKTOP: gnome
-            HDD_1: windows-10-x86_64-20H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
-            # poo#101620
-            QEMUMACHINE: 'pc-i440fx-4.2'
+            QEMUMACHINE: 'q35'
             PARALLEL_WITH: remote-desktop-supportserver4
             REGRESSION: remote
             REMOTE_DESKTOP_TYPE: win_client


### PR DESCRIPTION
The 20H2 HDD is a bit old meanwhile and has a cmd.exe window appearing on the
first login, which causes random test failures. Switch to the newer 21H2 HDD
which doesn't have that issue and also works with a newer machine type.

Verification runs:

Created job #2520836: opensuse-Tumbleweed-DVD-x86_64-Build20220816-remote-desktop-supportserver4@64bit -> https://openqa.opensuse.org/t2520836
Created job #2520837: opensuse-Tumbleweed-DVD-x86_64-Build20220816-remote-desktop-client4@64bit -> https://openqa.opensuse.org/t2520837

For the other two scenarios it's not easily possible to do VRs as clone-job applies the settings also to the supportserver job:

Created job #2520838: opensuse-Tumbleweed-DVD-x86_64-Build20220816-desktopapps-remote-desktop-xrdp-client2@64bit_virtio -> https://openqa.opensuse.org/t2520838
Created job #2520839: opensuse-Tumbleweed-DVD-x86_64-Build20220816-desktopapps-remote-desktop-xrdp-server2@64bit_virtio -> https://openqa.opensuse.org/t2520839

Created job #2520840: opensuse-Tumbleweed-DVD-x86_64-Build20220816-desktopapps-remote-desktop-xrdp-server1@64bit_virtio -> https://openqa.opensuse.org/t2520840
Created job #2520841: opensuse-Tumbleweed-DVD-x86_64-Build20220816-desktopapps-remote-desktop-xrdp-client1@64bit_virtio -> https://openqa.opensuse.org/t2520841
