### PR TITLE
opensuse_{leap,tumbleweed}: Add jeos-ltp-ima

### DIFF
--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -100,6 +100,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-dio:
           machine: 64bit_virtio
+      - jeos-ltp-ima:
+          machine: 64bit_virtio
       - jeos-ltp-syscalls:
           machine: 64bit_virtio
       - jeos-ltp-syscalls-ipc:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1015,6 +1015,8 @@ scenarios:
           machine: uefi_virtio-2G
       - jeos-ltp-dio:
           machine: uefi_virtio-2G
+      - jeos-ltp-ima:
+          machine: uefi_virtio-2G
       - jeos-ltp-syscalls:
           machine: uefi_virtio-2G
       - jeos-ltp-syscalls-ipc:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -532,6 +532,8 @@ scenarios:
           machine: aarch64-HD24G
       - jeos-ltp-dio:
           machine: aarch64-HD24G
+      - jeos-ltp-ima:
+          machine: aarch64-HD24G
       - jeos-ltp-syscalls:
           machine: aarch64-HD24G
       - jeos-ltp-syscalls-ipc:


### PR DESCRIPTION
NOTE: skip Leap 15.2, which is EOL.

verification run:
* opensuse-15.4-JeOS-for-kvm-and-xen-x86_64-Build7.15-jeos-ltp-ima@64bit_virtio
https://openqa.opensuse.org/tests/2538666

* opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20220823-jeos-ltp-ima@uefi_virtio-2G
https://openqa.opensuse.org/tests/2540366

* opensuse-Tumbleweed-JeOS-for-AArch64-aarch64-Build20220822-jeos-ltp-ima@aarch64-HD24G
https://openqa.opensuse.org/tests/2537865
