### PR TITLE
Leap 15.5: Add jeos-ltp-ima

### DIFF
--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -100,6 +100,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-dio:
           machine: 64bit_virtio
+      - jeos-ltp-ima:
+          machine: 64bit_virtio
       - jeos-ltp-syscalls:
           machine: 64bit_virtio
       - jeos-ltp-syscalls-ipc:


### PR DESCRIPTION
Why there is no verification run: **all** jobs in 15.5 fail: https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.5&build=6.5&groupid=103.

jeos-ltp-ima job was verified in 15.4: https://openqa.opensuse.org/tests/2538666 and Tumbleweed: https://openqa.opensuse.org/tests/2540366 as part of https://github.com/os-autoinst/opensuse-jobgroups/pull/191 (there is no reason why the test itself should not run in 15.5)

Reported by Fabian: https://github.com/os-autoinst/opensuse-jobgroups/pull/191#issuecomment-1226834011