### PR TITLE
Add missing variable CONTAINER_IMAGE_TO_TEST in Leap 15.5

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -162,10 +162,12 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'podman'
+            CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap:15.4'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'docker'
+            CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap:15.4'
       - extra_tests_ai_ml
       - upgrade_Leap_42.2_gnome:
           machine: 64bit


### PR DESCRIPTION
If this variable is not set, it will try to fetch the container image from lib/containers/urls.pm which is outdated.
It's just easier to add this variable than to update this url file for every new version.

The reason to use Leap 15.4 image is because 15.5 is not yet released and we use the stable version to be used as part of host tests.

https://progress.opensuse.org/issues/116497