### PR TITLE
Use machine types with virtio for Argon and Krypton

### DIFF
--- a/job_groups/opensuse_argon.yaml
+++ b/job_groups/opensuse_argon.yaml
@@ -23,7 +23,7 @@ scenarios:
       - krypton-live:
           machine: USBboot_64-2G
       - krypton-live-wayland:
-          machine: uefi-usb-2G
+          machine: uefi_virtio-2G
           settings:
-            QEMUVGA: virtio
+            USBBOOT: '1'
       - krypton-live-installation

--- a/job_groups/opensuse_krypton.yaml
+++ b/job_groups/opensuse_krypton.yaml
@@ -23,7 +23,7 @@ scenarios:
       - krypton-live:
           machine: USBboot_64-2G
       - krypton-live-wayland:
-          machine: uefi-usb-2G
+          machine: uefi_virtio-2G
           settings:
-            QEMUVGA: virtio
+            USBBOOT: '1'
       - krypton-live-installation


### PR DESCRIPTION
Those define the necessary UEFI_PFLASH_VARS for QEMUVGA=virtio (poo#113794).