### PR TITLE
Disable push of container stats

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -173,7 +173,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'
       - container_image_on_leap15.2_host:
           testsuite: container-image
@@ -261,5 +262,6 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -181,7 +181,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'
       - container_image_on_leap15.2_host:
           testsuite: container-image
@@ -280,5 +281,6 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -181,7 +181,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'
       - container_image_on_leap15.2_host:
           testsuite: container-image
@@ -280,5 +281,6 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5'
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -328,7 +328,8 @@ scenarios:
             CONTAINER_RUNTIME: 'docker,podman'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'
       - extra_tests_ai_ml
       - yast_no_self_update

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -260,7 +260,8 @@ scenarios:
           settings:
             CONTAINER_RUNTIME: 'docker,podman'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
-            IMAGE_STORE_DATA: '1'
+            # Temporarily disabled due to db instance being down
+            IMAGE_STORE_DATA: '0'
             POSTGRES_IP: '18.196.183.86'
       - create_hdd_textmode_secureboot:
           testsuite: null


### PR DESCRIPTION
Temporarily disable the pushing of container stats to the database server because the server is not available at the moment.