### PR TITLE
ALP LTP job improvements

### DIFF
--- a/job_groups/alp.yaml
+++ b/job_groups/alp.yaml
@@ -42,7 +42,7 @@
   BOOT_HDD_IMAGE: '1'
   DESKTOP: 'textmode'
   GRUB_PARAM: 'debug_pagealloc=on;ima_policy=tcb'
-  HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
+  +HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
   INSTALL_LTP: 'from_repo'
   LTP_ENV: 'LVM_DIR=/var/tmp/'
   PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2'
@@ -55,7 +55,7 @@
 .ltp: &ltp
   BOOT_HDD_IMAGE: '1'
   DESKTOP: 'textmode'
-  HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2'
+  +HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2'
   QEMUCPUS: '2'
   LTP_KNOWN_ISSUES: 'https://raw.githubusercontent.com/openSUSE/kernel-qe/main/ltp_known_issues.yaml'
   START_AFTER_TEST: 'install_ltp'

--- a/job_groups/alp.yaml
+++ b/job_groups/alp.yaml
@@ -57,6 +57,7 @@
   DESKTOP: 'textmode'
   HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%FLAVOR%@%MACHINE%-with-ltp.qcow2'
   QEMUCPUS: '2'
+  LTP_KNOWN_ISSUES: 'https://raw.githubusercontent.com/openSUSE/kernel-qe/main/ltp_known_issues.yaml'
   START_AFTER_TEST: 'install_ltp'
 
 .ltp_cve: &ltp_cve


### PR DESCRIPTION
We need to add support of LTP known issues to ALP to ignore known failures.

HDD_1 settings needs to be forced in job group, otherwise original HDD_1 is used.

