### PR TITLE
Add test for apptainer package on TW

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -322,6 +322,10 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
+      - containers_hpc_apptainer:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIME: 'apptainer'
       - containers_image:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -255,6 +255,10 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'containerd_clictl,containerd_nerdctl'
+      - containers_hpc_apptainer:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIME: 'apptainer'
       - containers_image:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
This package is maintained by HPC repos but it is not available yet for HPC. However it is on factory and we want to follow the Factory first policy and cover it before make it through on SLE.

The module covers basic operation of the tool. Apptainer is the new name of singularity.

https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2315562
https://openqa.opensuse.org/tests/overview?distri=microos&version=Tumbleweed&build=b10n1k%2Fos-autoinst-distri-opensuse%2315562

[aarch64](https://openqa.opensuse.org/tests/2774018)

Signed-off-by: ybonatakis <ybonatakis@suse.com>