### PR TITLE
Leap update installation via autoyast

### DIFF
--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -36,34 +36,80 @@ products:
 scenarios:
   x86_64:
     opensuse-15.4-DVD-Updates-x86_64:
+      - autoyast_leap_videomode_text
+      - create_hdd_leap_gnome_autoyast
+      - create_hdd_leap_kde_autoyast
+      - create_hdd_leap_textmode_autoyast
+      - create_hdd_leap_gnome_uefi_autoyast:
+          machine: 'uefi'
+          testsuite: 'create_hdd_leap_gnome_autoyast'
+          settings:
+            UEFI_PFLASH_VARS: 'ovmf-x86_64-ms-vars-800x600.qcow2'
+      - create_hdd_leap_kde_uefi_autoyast:
+          machine: 'uefi'
+          testsuite: 'create_hdd_leap_kde_autoyast'
+          settings:
+            UEFI_PFLASH_VARS: 'ovmf-x86_64-ms-vars-800x600.qcow2'
+      - create_hdd_leap_textmode_uefi_autoyast:
+          machine: 'uefi'
+          testsuite: 'create_hdd_leap_textmode_autoyast'
+          settings:
+            UEFI_PFLASH_VARS: 'ovmf-x86_64-ms-vars-800x600.qcow2'
       - textmode
       - cryptlvm:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
-      - install_with_updates_gnome:
-          machine: uefi-2G
-          settings:
-            QEMUVGA: cirrus
-      - install_with_updates_kde:
-          machine: uefi-2G
-          # poo#95137
-          settings:
-            EXCLUDE_MODULES: 'kontact'
       - create_hdd_gnome
       - create_hdd_kde
       - create_hdd_textmode
-      - extra_tests_on_kde
-      - extra_tests_textmode
-      - extra_tests_webserver
-      - extra_tests_gnome
-      - extra_tests_filesystem
-      - extra_tests_webframeworks
-      - gnuhealth
-      - toolkits
-      - openqa_bootstrap
+      - extra_tests_on_kde:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_kde_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - extra_tests_textmode:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+            EXCLUDE_MODULES: 'autoyast_removed'
+      - extra_tests_webserver:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - extra_tests_gnome:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_gnome_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - extra_tests_filesystem:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - extra_tests_webframeworks:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - gnuhealth:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_gnome_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - toolkits:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_gnome_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - openqa_bootstrap:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_gnome_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
       # poo#107242
       # - openqa_bootstrap_container
-      - extra_tests_misc
+      - extra_tests_misc:
+          settings:
+            START_AFTER_TEST: 'create_hdd_leap_gnome_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
+      - extra_tests_leap_update_textmode_2
+      - extra_tests_leap_update_gnome_uefi:
+          machine: 'uefi'
+      - extra_tests_leap_update_kde_uefi:
+          machine: 'uefi'
       - zdup-Leap-15.2-gnome:
           settings:
             <<: *zdup
@@ -102,22 +148,28 @@ scenarios:
           machine: uefi
           settings:
             QEMU_VIRTIO_RNG: "0"
-      - apparmor
-      - autoyast_gnome:
+      - apparmor:
           settings:
-            AUTOYAST: autoyast_opensuse/opensuse_leap_gnome.xml
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
       - extra_tests_textmode_podman_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'podman'
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
       - extra_tests_textmode_kubectl_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'kubectl'
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'docker'
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
       - create_hdd_transactional_server:
           settings:
             # use main.pm schedule over YAML as it is used among other create_hdd test suite in updates testing
@@ -130,6 +182,8 @@ scenarios:
       - security_audit:
           settings:
             YAML_SCHEDULE: schedule/security/audit.yaml
+            START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
   aarch64:
     opensuse-15.4-DVD-Updates-aarch64:
       - create_hdd_gnome:


### PR DESCRIPTION
https://progress.opensuse.org/issues/116006
Increase the coverage of test scenarios in Leap Maintainance, Prepare tests that are using interactive installer to use autoyast

VR:
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.4&build=20221024-1&groupid=39