### PR TITLE
ltp: Use ALP repo in OBS

### DIFF
--- a/job_groups/alp.yaml
+++ b/job_groups/alp.yaml
@@ -52,7 +52,7 @@
   QEMUCPUS: '4'
   QEMURAM: '4096'
   START_AFTER_TEST: 'alp_default'
-  QA_HEAD_REPO: 'http://download.opensuse.org/repositories/benchmark:/ltp:/stable/openSUSE_Tumbleweed/'
+  QA_HEAD_REPO: 'http://download.opensuse.org/repositories/benchmark:/ltp:/stable/ALP/'
   LTP_PKG: 'ltp-stable'
 
 .ltp: &ltp


### PR DESCRIPTION
openSUSE Tumbleweed repository in OBS was temporary solution. ALP build repository is available now and we can use it for LTP installation.