### PR TITLE
tumbleweed: aarch64: Use aarch64-HD20G/aarch32-HD20G machines for JeOS

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -522,24 +522,39 @@ scenarios:
           priority: 40
     opensuse-Tumbleweed-JeOS-for-AArch64-aarch64:
       - jeos:
+          machine: aarch64-HD20G
           priority: 45
           settings:
             INFLUXDB_SERVER: '18.196.183.86'
       - jeos-extra:
+          machine: aarch64-HD20G
           priority: 45
-      - jeos-apparmor
-      - jeos-container_host
-      - jeos-container_image
-      - jeos-filesystem
-      - jeos-fips
-      - jeos-ltp-commands
-      - jeos-ltp-containers
-      - jeos-ltp-cve
-      - jeos-ltp-dio
-      - jeos-ltp-ima
-      - jeos-ltp-syscalls
-      - jeos-ltp-syscalls-ipc
+      - jeos-apparmor:
+          machine: aarch64-HD20G
+      - jeos-container_host:
+          machine: aarch64-HD20G
+      - jeos-container_image:
+          machine: aarch64-HD20G
+      - jeos-filesystem:
+          machine: aarch64-HD20G
+      - jeos-fips:
+          machine: aarch64-HD20G
+      - jeos-ltp-commands:
+          machine: aarch64-HD20G
+      - jeos-ltp-containers:
+          machine: aarch64-HD20G
+      - jeos-ltp-cve:
+          machine: aarch64-HD20G
+      - jeos-ltp-dio:
+          machine: aarch64-HD20G
+      - jeos-ltp-ima:
+          machine: aarch64-HD20G
+      - jeos-ltp-syscalls:
+          machine: aarch64-HD20G
+      - jeos-ltp-syscalls-ipc:
+          machine: aarch64-HD20G
       - zdup_twjeos2twnext_aarch64:
+          machine: aarch64-HD20G
           priority: 45
     opensuse-Tumbleweed-JeOS-for-RPi-aarch64:
       - jeos:
@@ -620,8 +635,10 @@ scenarios:
   armv7hl:
     opensuse-Tumbleweed-JeOS-for-AArch64-armv7hl:
       - jeos:
+          machine: aarch32-HD20G
           priority: 45
       - jeos-extra:
+          machine: aarch32-HD20G
           settings:
             EXCLUDE_MODULES: kdump_and_crash
     opensuse-Tumbleweed-JeOS-for-RPi-armv7hl:


### PR DESCRIPTION
to set the HDD size since HDDSIZEGB from aarch64/aarch32 machines does not apply here