### PR TITLE
LTP: Disable ltp_irq

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -70,7 +70,6 @@ scenarios:
       - ltp_input
       - ltp_io
       - ltp_ipc
-      - ltp_irq
       - ltp_kernel_misc
       - ltp_kernel_sched
       - ltp_lvm
@@ -154,7 +153,6 @@ scenarios:
       - ltp_input
       - ltp_io
       - ltp_ipc
-      - ltp_irq
       - ltp_kernel_misc
       - ltp_kernel_sched
       - ltp_lvm
@@ -237,7 +235,6 @@ scenarios:
       - ltp_input
       - ltp_io
       - ltp_ipc
-      - ltp_irq
       - ltp_kernel_misc
       - ltp_kernel_sched
       - ltp_lvm


### PR DESCRIPTION
Test is broken on ppc64le on Tumbleweed, but remove from all archs.

This test was contributed as it's important for SLES on some hardware which doesn't distribute IRQs automatically, it does not make much sense to run it in o3.