### PR TITLE
Fix diff-filter parameters in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
           git remote set-url origin $real_origin_url
           git fetch origin master:omaster
           git rebase omaster
-          git diff --diff-filter="*ACMRTUXD" omaster job_groups/
-          CHANGED_FILES=$(git diff --diff-filter="*ACMRTUX" --name-only origin/master job_groups/ | tr '\n' ' ')
+          git diff --diff-filter="ACMRTUXD" omaster job_groups/
+          CHANGED_FILES=$(git diff --diff-filter="ACMRTUX" --name-only origin/master job_groups/ | tr '\n' ' ')
           echo $CHANGED_FILES
           echo "::set-output name=files::${CHANGED_FILES}"
 


### PR DESCRIPTION
- progress ticket: https://progress.opensuse.org/issues/121432

The CI step `Run yamllint for modified job group schedules` will - correctly - not fail if a file is deleted, since the diff filter used by the previous step to calculate changed files is `--diff-filter="*ACMRTUX"`, which doesn't include `D` (**D**eleted).

However, the step will fail (incorrectly, due to the removed file) if there's any other change (like changes in files or added files) that are included in the filter, together with a file removal. That is because of the `*` in the filter, which means "if any of the filter parameters match, return all differences".

This pr removes the `*` filter (select-all-if-any-matches), to avoid getting wrong CI failures for deleted files.