### PR TITLE
LTP: Fix testsuite name after rename

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -39,8 +39,7 @@ scenarios:
           settings:
             CRASH_MEMORY: '320'
       - install_ltp+opensuse+DVD
-      - ltp_aio_stress_part1
-      - ltp_aio_stress_part2
+      - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2
       - ltp_aiodio_part3
@@ -122,8 +121,7 @@ scenarios:
             CRASH_MEMORY: '640'
       - install_ltp+opensuse+DVD
       - kernel-live-patching
-      - ltp_aio_stress_part1
-      - ltp_aio_stress_part2
+      - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2
       - ltp_aiodio_part3
@@ -203,8 +201,7 @@ scenarios:
       - kdump
       - install_ltp+opensuse+DVD
       - kernel-live-patching
-      - ltp_aio_stress_part1
-      - ltp_aio_stress_part2
+      - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2
       - ltp_aiodio_part3


### PR DESCRIPTION
ltp-aio-stress.part1 and ltp-aio-stress.part2 were merged in [1], thus replace them with ltp_aio_stress job.

[1] https://github.com/linux-test-project/ltp/commit/c91a2f91fbc2101c22d7f2f101c9cd8531fe126b