### PR TITLE
LTP/s390x: Add few tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -204,7 +204,9 @@ scenarios:
       - xfstests_btrfs-btrfs-001-050
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
-      - install_ltp_s390x
+      - ltp_cve_s390x
+      - ltp_crypto_pty_commands_s390x
+      - ltp_syscalls_s390x
   x86_64:
     opensuse-Tumbleweed-DVD-x86_64:
       - extra_tests_kernel


### PR DESCRIPTION
Add 3 LTP testsuites: cve, syscalls and crypto, pty, commands (these 3 run together). These must install OS and LTP, because there is no s390 KVM instance in o3, thus tests must use bootloader_s390.pm (instead of bootloader_zkvm.pm) which does not support reboot. Therefore START_DIRECTLY_AFTER_TEST trick used on bare metal is useless.

Remove install_ltp_s390x as it's also useless now.

Verification run:
* ltp_cve@s390x https://openqa.opensuse.org/tests/2957122 (here with pty)
* ltp_syscalls@s390x https://openqa.opensuse.org/tests/2957106
* ltp_crypto_pty_commands@s390x https://openqa.opensuse.org/tests/2957172