### PR TITLE
kernel: Move some default setup from openQA to git

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -18,6 +18,13 @@ defaults:
   s390x:
     machine: s390x-zVM-vswitch-l2
     priority: 60
+    settings:
+      # required by bootloader_s390 (o3 does not support zkvm, only z/VM, thus
+      # installation must be done for each test suite
+      INSTALL_LTP: 'from_repo'
+      LTP_BAREMETAL: '1'
+      VIDEOMODE: 'text'
+      MAX_JOB_TIME: '14400'
   x86_64:
     machine: 64bit
     priority: 60
@@ -204,9 +211,12 @@ scenarios:
       - xfstests_btrfs-btrfs-001-050
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
-      - ltp_cve_s390x
-      - ltp_crypto_pty_commands_s390x
-      - ltp_syscalls_s390x
+      - ltp_cve
+      - ltp_crypto_pty_commands
+      - ltp_syscalls
+      - kernel-live-patching:
+          settings:
+            INSTALL_LTP: ''
   x86_64:
     opensuse-Tumbleweed-DVD-x86_64:
       - extra_tests_kernel

--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -12,6 +12,9 @@ defaults:
   aarch64:
     machine: aarch64
     priority: 60
+  i586:
+    machine: 32bit
+    priority: 60
   ppc64le:
     machine: ppc64le
     priority: 60
@@ -32,6 +35,10 @@ products:
   opensuse-Tumbleweed-DVD-aarch64:
     distri: opensuse
     flavor: DVD
+    version: Tumbleweed
+  opensuse-Tumbleweed-LegacyX86-NET-i586:
+    distri: opensuse
+    flavor: LegacyX86-NET
     version: Tumbleweed
   opensuse-Tumbleweed-DVD-ppc64le:
     distri: opensuse
@@ -127,6 +134,12 @@ scenarios:
       - nfs_pynfs_nfs41_all
       - create_hdd_xfstests
       - xfstests_btrfs-btrfs-001-050
+  i586:
+    opensuse-Tumbleweed-LegacyX86-NET-i586:
+      - install_ltp+opensuse+LegacyX86-NET
+      - ltp_cve
+      - ltp_crypto
+      - ltp_syscalls
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
       - extra_tests_kernel


### PR DESCRIPTION
To have s390x specific setup here will allow:

1) not have specific s390x test suites
2) have backup of the specific setup (in case of broken DB and lost data)

NOTE: Not sure if text mode installation is faster, but currently (20221218) GUI installation fails. To set text mode installation only VIDEOMODE=text is needed - it sets DESKTOP=textmode, thus not adding it. By default it'd be DESKTOP=kde.
    
UPDATE: Also add:
* `kernel-live-patching@s390x` test: https://openqa.opensuse.org/tests/2971580 (requires https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16145)
* i586 cve and syscalls: https://openqa.opensuse.org/tests/2973369 https://openqa.opensuse.org/tests/2973410 https://openqa.opensuse.org/tests/2973411

UPDATE: `LTP_BAREMETAL=1` is not needed once this PR is merged: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16145