### PR TITLE
Add a group to create disk images based on GM

### DIFF
--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -71,3 +71,4 @@
 104: opensuse_leap_15.5_armv7_images
 105: alp-staging
 106: opensuse_leap_15.5_armv7
+107: support_images

--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -1,0 +1,28 @@
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#              job_groups/support_images.yaml              #
+############################################################
+---
+defaults:
+  x86_64:
+    machine: 64bit
+    priority: 60
+products:
+  opensuse-15.4-DVD-Updates-x86_64:
+    distri: opensuse
+    flavor: DVD-Updates
+    version: '15.4'
+scenarios:
+  x86_64:
+    opensuse-15.4-DVD-Updates-x86_64:
+      - create_hdd_leap_textmode_autoyast_dev:
+          testsuite: create_hdd_leap_textmode_autoyast
+          settings:
+            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
+            OS_TEST_ISSUES: ""
+            QA_HEAD_REPO: ""


### PR DESCRIPTION
Job group to create disk images based on GM with latest updates from default Opensuse repositories, that will be used by other jobs, for example for upgrade from Leap to Tumbleweed. 
See https://progress.opensuse.org/issues/122170

For now, only adding a "dummy" test.