### PR TITLE
Exclude yast2_rmt module from TW on i586

### DIFF
--- a/job_groups/opensuse_tumbleweed_legacy_x86.yaml
+++ b/job_groups/opensuse_tumbleweed_legacy_x86.yaml
@@ -51,3 +51,5 @@ scenarios:
       - yast2_ncurses:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            # yast2-rmt package not build on i586
+            EXCLUDE_MODULES: yast2_rmt


### PR DESCRIPTION
Package yast2-rmt is not build on TW i586, so module yast2_rmt needs to be excluded from relevant runs.
An exclusion mechanism was already introduced for main_common.pm (see [this PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16096)). 
The current change concerns the module's exclusion from the YAML scheduling.

Related ticket: https://progress.opensuse.org/issues/121948
