### PR TITLE
Update CentOS8 HDD

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -152,7 +152,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
+            HDD_1: 'centOS-Stream-8-x86_64-20221228-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -160,7 +160,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
+            HDD_1: 'centOS-Stream-8-x86_64-20221228-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -160,7 +160,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
+            HDD_1: 'centOS-Stream-8-x86_64-20221228-minimal.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1095,7 +1095,7 @@ scenarios:
             VIDEOMODE: text
             KEEP_GRUB_TIMEOUT: '1'
             BOOT_HDD_IMAGE: '1'
-            HDD_1: 'centOS-Stream-8-x86_64-20220128-minimal.qcow2'
+            HDD_1: 'centOS-Stream-8-x86_64-20221228-minimal.qcow2'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed'
             CONTAINERS_NO_SUSE_OS: "1"


### PR DESCRIPTION
The CentOS-8 HDD was old and needed an update. I pushed a new HDD to o3 and this commit updates the HDD_1 setting accordingly.

* Related ticket: https://progress.opensuse.org/issues/122482
* Verification run: https://openqa.opensuse.org/tests/2990141