### PR TITLE
Set up 15.4 to 15.5 upgrade tests

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -230,6 +230,8 @@ scenarios:
       - zdup-Leap-15.3-kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - zdup-Leap-15.4-gnome
+      - zdup-Leap-15.4-kde_to_Leap
       - upgrade_Leap_42.3_gnome:
           machine: 64bit
       - upgrade_Leap_42.3_kde:
@@ -294,6 +296,8 @@ scenarios:
       - upgrade_Leap_15.3_kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - upgrade_Leap_15.4_gnome
+      - upgrade_Leap_15.4_kde
       - upgrade_Leap_15.2_cryptlvm:
           machine: uefi
           settings:
@@ -302,6 +306,8 @@ scenarios:
           machine: uefi
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - upgrade_Leap_15.4_cryptlvm:
+          machine: uefi
       - installer_extended
       - btrfs:
           settings:
@@ -432,10 +438,14 @@ scenarios:
       - upgrade_Leap_15.3_kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - upgrade_Leap_15.4_gnome
+      - upgrade_Leap_15.4_kde
       - upgrade_Leap_15.3_cryptlvm:
           machine: uefi
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - upgrade_Leap_15.4_cryptlvm:
+          machine: uefi
       - zdup-Leap-15.2-gnome:
           settings:
             QEMU_VIRTIO_RNG: "0"
@@ -450,6 +460,8 @@ scenarios:
       - zdup-Leap-15.3-kde:
           settings:
             QEMU_VIRTIO_RNG: "0"
+      - zdup-Leap-15.4-gnome
+      - zdup-Leap-15.4-kde_to_Leap
   aarch64:
     opensuse-Leap-15.5-DVD-aarch64:
       - textmode:


### PR DESCRIPTION
https://progress.opensuse.org/issues/117520

set up tests for Leap 15.4 upgrade to Leap 15.5,
including upgrading via zypper and installer.

VR: [test results in dev job group](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.5&build=366.5&groupid=39)
Please omit the failed cases, they can be found on other older leap versions. I will file new tickets/bugs to track them.