### PR TITLE
kernel/s390x: Clear HDD_1

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -24,6 +24,7 @@ defaults:
     settings:
       # required by bootloader_s390 (o3 does not support zkvm, only z/VM, thus
       # installation must be done for each test suite
+      HDD_1: ''
       INSTALL_LTP: 'from_repo'
       LTP_BAREMETAL: '1'
       VIDEOMODE: 'text'


### PR DESCRIPTION
This is needed because s390x tests on o3 are z/VM, thus they aren't QEMU based.