### PR TITLE
Create auto-installation for Leap 15.4 in Yam Support job group in O3

### DIFF
--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -20,9 +20,13 @@ products:
 scenarios:
   x86_64:
     opensuse-15.4-DVD-Updates-x86_64:
-      - create_hdd_leap_textmode_autoyast_dev:
-          testsuite: create_hdd_leap_textmode_autoyast
+      - create_hdd_leap_gnome_autoyast_updated:
+          testsuite: null
           settings:
-            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
+            DESKTOP: gnome
+            HDDSIZEGB: "30"
             OS_TEST_ISSUES: ""
-            QA_HEAD_REPO: ""
+            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
+            PUBLISH_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%-uefi-vars.qcow2"
+            QEMURAM: "2048"
+            YAML_SCHEDULE: schedule/functional/autoyast_create_hdd/autoyast_create_hdd_leap_update.yaml


### PR DESCRIPTION
We need create auto-installation for Leap 15.4 in Yam Support job group in O3.
Related ticket: https://progress.opensuse.org/issues/122173
VR:
    Created job for the qcow of leap 15.4: https://openqa.opensuse.org/tests/3100615#
    VR for failed job: https://openqa.opensuse.org/tests/3101018#step/opensuse_welcome/3  failed for needle issue now, but can't save a new needle for git issue.