### PR TITLE
tumbleweed: aarch64: Increase priority of jeos@aarch64_cpu_max-HD20G

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -529,6 +529,7 @@ scenarios:
             INFLUXDB_SERVER: '18.196.183.86'
       - jeos:
           machine: aarch64_cpu_max-HD20G
+          priority: 45
       - jeos-extra:
           machine: aarch64-HD20G
           priority: 45


### PR DESCRIPTION
because it is a long run