### PR TITLE
Set WORKER_CLASS=wsl2 on WSL2 tests

### DIFF
--- a/job_groups/opensuse_leap_15.4_wsl.yaml
+++ b/job_groups/opensuse_leap_15.4_wsl.yaml
@@ -50,7 +50,7 @@ scenarios:
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
             QEMUCPUS: '2'
-            WORKER_CLASS: 'openqaworker7'
+            WORKER_CLASS: 'qemu_x86_64,wsl2'
       - wsl-install-MSStore-Leap15.4:
           testsuite: null
           description: |

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1170,3 +1170,4 @@ scenarios:
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
             QEMUCPUS: '2'
+            WORKER_CLASS: 'qemu_x86_64,wsl2'


### PR DESCRIPTION
The image only works on some workers (needs specific CPUs) and on top of that they also need an older kernel as workaround for boo#1206616.