### PR TITLE
Added START_AFTER_TEST of auto-installation leap15.4

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -299,6 +299,7 @@ scenarios:
           settings:
             HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
             ORIGIN_SYSTEM_VERSION: '15.4'
+            START_AFTER_TEST: create_hdd_leap_gnome_autoyast_updated
       - gnome+do_not_import_ssh_keys:
           machine: 64bit_cirrus-2G
       - autoyast_y2_firstboot


### PR DESCRIPTION
We need add START_AFTER_TEST so that it won't start before auto-installation job finished. 

