### PR TITLE
Update qcow name without build id leap15.4

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -297,9 +297,8 @@ scenarios:
       - gnome+import_ssh_keys:
           machine: 64bit_cirrus
           settings:
-            HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
+            HDD_1: opensuse-updated-15.4-%ARCH%-%DESKTOP%.qcow2
             ORIGIN_SYSTEM_VERSION: '15.4'
-            START_AFTER_TEST: create_hdd_leap_gnome_autoyast_updated
       - gnome+do_not_import_ssh_keys:
           machine: 64bit_cirrus-2G
       - autoyast_y2_firstboot

--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -26,7 +26,7 @@ scenarios:
             DESKTOP: gnome
             HDDSIZEGB: "30"
             OS_TEST_ISSUES: ""
-            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%-%BUILD%.qcow2
-            PUBLISH_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%-uefi-vars.qcow2"
+            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%.qcow2
+            PUBLISH_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%_ay@%MACHINE%-uefi-vars.qcow2"
             QEMURAM: "2048"
             YAML_SCHEDULE: schedule/functional/autoyast_create_hdd/autoyast_create_hdd_leap_update.yaml


### PR DESCRIPTION
create_hdd_leap_gnome_autoyast_updated and gnome+import_ssh_keys are in different flavor, so can't use START_AFTER_TEST to chain, we update the auto-installation qcow name without build id to fix this issue.

Failed job: https://openqa.opensuse.org/tests/3108983#
VR of auto-installation of leap 15.4: https://openqa.opensuse.org/tests/3109463#
VR for failed job: https://openqa.opensuse.org/tests/3109578#