### PR TITLE
Update opensuse_leap_15.yaml

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -326,7 +326,8 @@ scenarios:
       - openscap:
           settings:
             QEMUCPU: 'host'
-            QEMURAM: '2048'
+            QEMUCPUS: '2'
+            QEMURAM: '4096'
       - autoyast_y2_firstboot:
           settings:
             AUTOYAST: autoyast_opensuse/autoyast_firstboot_leap.xml


### PR DESCRIPTION
On x86_64, openscap requires more resources to successfully run.

Related ticket: https://progress.opensuse.org/issues/116368
VRs:
* https://openqa.opensuse.org/tests/3115462
* https://openqa.opensuse.org/tests/3115464