### PR TITLE
Update qcow name without version

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -297,8 +297,7 @@ scenarios:
       - gnome+import_ssh_keys:
           machine: 64bit_cirrus
           settings:
-            HDD_1: opensuse-updated-15.4-%ARCH%-%DESKTOP%.qcow2
-            ORIGIN_SYSTEM_VERSION: '15.4'
+            HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
       - gnome+do_not_import_ssh_keys:
           machine: 64bit_cirrus-2G
       - autoyast_y2_firstboot

--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -11,7 +11,7 @@
 defaults:
   x86_64:
     machine: 64bit
-    priority: 60
+    priority: 40
 products:
   opensuse-15.4-DVD-Updates-x86_64:
     distri: opensuse
@@ -26,7 +26,7 @@ scenarios:
             DESKTOP: gnome
             HDDSIZEGB: "30"
             OS_TEST_ISSUES: ""
-            PUBLISH_HDD_1: opensuse-updated-%VERSION%-%ARCH%-%DESKTOP%.qcow2
-            PUBLISH_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%DESKTOP%_ay@%MACHINE%-uefi-vars.qcow2"
+            PUBLISH_HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
+            PUBLISH_PFLASH_VARS: "opensuse-leap-updated-%ARCH%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
             QEMURAM: "2048"
             YAML_SCHEDULE: schedule/functional/autoyast_create_hdd/autoyast_create_hdd_leap_update.yaml


### PR DESCRIPTION
Updadte qcow name without version, so it won't depend on special leap version.

VRs: auto-installation: https://openqa.opensuse.org/tests/3118962#details
        gnome+import_ssh_keys : https://openqa.opensuse.org/tests/3119388#details