### PR TITLE
[WIP]Move 2 virtualization tests to TW job group for daily review from development group

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -905,6 +905,10 @@ scenarios:
           machine: uefi
           settings:
             DESKTOP: textmode
+      - virt-guest-installation-kvm:
+          machine: 64bit-ipmi
+      - virt-guest-installation-xen:
+          machine: 64bit-ipmi
     opensuse-Tumbleweed-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi


### PR DESCRIPTION
They are two tests from virtualization qa team with ipmi backends. 

- related ticket: https://progress.opensuse.org/issues/103742

The two latest runs:
https://openqa.opensuse.org/tests/3122754    //Failed due to unstable download.opensuse.org
https://openqa.opensuse.org/tests/3122755    //PASS

@alice-suse @xguo @waynechen55 @nanzhg @tbaev @RoyCai7 @varunkojha and O3 maintainers, Welcome review!