### PR TITLE
Reduce frequency for auto-installed qcow

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -300,6 +300,8 @@ scenarios:
             HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
       - gnome+do_not_import_ssh_keys:
           machine: 64bit_cirrus-2G
+          settings:
+            HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
       - autoyast_y2_firstboot
       - autoyast_btrfs_quota
       - autoyast_gnome:

--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -13,18 +13,20 @@ defaults:
     machine: 64bit
     priority: 40
 products:
-  opensuse-15.4-DVD-Updates-x86_64:
+  opensuse-15.4-DVD-x86_64:
     distri: opensuse
-    flavor: DVD-Updates
+    # Select DVD flavor while not DVD-Updates to less frequency for auto-generate support images.
+    flavor: DVD
     version: '15.4'
 scenarios:
   x86_64:
-    opensuse-15.4-DVD-Updates-x86_64:
+    opensuse-15.4-DVD-x86_64:
       - create_hdd_leap_gnome_autoyast_updated:
           testsuite: null
           settings:
             DESKTOP: gnome
             HDDSIZEGB: "30"
+            ISO: openSUSE-Leap-15.0-DVD-x86_64.iso
             OS_TEST_ISSUES: ""
             PUBLISH_HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
             PUBLISH_PFLASH_VARS: "opensuse-leap-updated-%ARCH%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"


### PR DESCRIPTION
As the new feedback, we need reduce the frequency for auto-installed qcow and update  gnome+do_not_import_ssh_keys.

related ticket: https://progress.opensuse.org/issues/122173