### PR TITLE
Assign more RAM to KDE-Live tests

### DIFF
--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -133,15 +133,15 @@ scenarios:
           machine: 64bit_virtio-2G
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi
+          machine: uefi-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.3:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.4-Rescue-CD-x86_64:

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -133,15 +133,15 @@ scenarios:
           machine: 64bit_virtio-2G
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi
+          machine: uefi-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.3:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.5-Rescue-CD-x86_64:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -962,31 +962,33 @@ scenarios:
           machine: uefi_virtio-2G
     opensuse-Tumbleweed-KDE-Live-x86_64:
       - kde-live:
-          machine: uefi-2G
+          machine: uefi-3G
           priority: 48
       - kde-live:
-          machine: uefi-usb
+          machine: uefi-usb-2G
           priority: 48
       - kde-live:
-          machine: 64bit
+          machine: 64bit-3G
           priority: 48
       - kde-live:
-          machine: USBboot_64
+          machine: USBboot_64-2G
           priority: 48
       - mediacheck:
           machine: 64bit
       - kde-live_installation:
-          machine: uefi-2G
+          machine: uefi-3G
       - kde-live_installation:
-          machine: 64bit
+          machine: 64bit-3G
       - kde-live-wayland:
           machine: 64bit_virtio-3G
       - kde_live_upgrade_leap_15.0:
+          machine: 64bit-3G
           settings:
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi
+          machine: uefi-3G
       - kde_live_upgrade_leap_15.3:
+          machine: 64bit-3G
           settings:
             QEMU_VIRTIO_RNG: "0"
     opensuse-Tumbleweed-NET-x86_64:


### PR DESCRIPTION
KDE-Live tests with overlay in RAM need 3G for faster test execution, particularly for Firefox.

For installation and upgrades scenarios, 2G are sufficient.