### PR TITLE
In upgrade tests, keep MACHINE and set QEMURAM explicitly instead

### DIFF
--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -133,16 +133,19 @@ scenarios:
           machine: 64bit_virtio-2G
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
-          machine: 64bit-2G
+          machine: 64bit
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi-2G
+          machine: uefi
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.3:
-          machine: 64bit-2G
+          machine: 64bit
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.4-Rescue-CD-x86_64:
       - rescue

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -133,16 +133,19 @@ scenarios:
           machine: 64bit_virtio-2G
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
-          machine: 64bit-2G
+          machine: 64bit
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi-2G
+          machine: uefi
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.3:
-          machine: 64bit-2G
+          machine: 64bit
           settings:
+            QEMURAM: "2048"
             QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.5-Rescue-CD-x86_64:
       - rescue

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -982,14 +982,16 @@ scenarios:
       - kde-live-wayland:
           machine: 64bit_virtio-3G
       - kde_live_upgrade_leap_15.0:
-          machine: 64bit-3G
           settings:
+            QEMURAM: "3072"
             QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.2:
-          machine: uefi-3G
-      - kde_live_upgrade_leap_15.3:
-          machine: 64bit-3G
+          machine: uefi
           settings:
+            QEMURAM: "3072"
+      - kde_live_upgrade_leap_15.3:
+          settings:
+            QEMURAM: "3072"
             QEMU_VIRTIO_RNG: "0"
     opensuse-Tumbleweed-NET-x86_64:
       - textmode:


### PR DESCRIPTION
%MACHINE% is used by the HDD_1 var, so the upgrade tests couldn't find their disks anymore.