### PR TITLE
Avoid adding invalid repo for leap 15.5

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -515,6 +515,7 @@ scenarios:
       - yast2_gui:
           settings:
             QEMU_VIRTIO_RNG: "0"
+            KEEP_ONLINE_REPOS: "1"
       - extra_tests_on_gnome
       - create_hdd_xfce:
           settings:


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/124889
VR: https://openqa.opensuse.org/tests/3161819#step/yast2_control_center/39