### PR TITLE
Create new yaml schedule for leap

### DIFF
--- a/job_groups/opensuse_leap_15.4_continous_rebuild.yaml
+++ b/job_groups/opensuse_leap_15.4_continous_rebuild.yaml
@@ -223,7 +223,7 @@ scenarios:
           machine: 64bit
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - upgrade_Leap_42.3_cryptlvm:
           machine: uefi
       - toolchain_zypper
@@ -408,7 +408,7 @@ scenarios:
       - kde-wayland
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - virtualization:
           settings:
             YAML_SCHEDULE: schedule/virtualization/virtualization.yaml
@@ -511,7 +511,7 @@ scenarios:
             QEMU_VIRTIO_RNG: "0"
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - extra_tests_dracut
   s390x:
     opensuse-Leap-15.4-CR-DVD-s390x:

--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -237,7 +237,7 @@ scenarios:
           machine: 64bit
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - upgrade_Leap_42.3_cryptlvm:
           machine: uefi
       - toolchain_zypper
@@ -556,7 +556,7 @@ scenarios:
       - kde-wayland
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - virtualization:
           settings:
             YAML_SCHEDULE: schedule/virtualization/virtualization.yaml
@@ -682,7 +682,7 @@ scenarios:
             QEMU_VIRTIO_RNG: "0"
       - yast2_ncurses:
           settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
+            YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - extra_tests_dracut
     opensuse-Leap-15.5-NET-ppc64le:
       - minimalx:


### PR DESCRIPTION
In Tumbleweed job group, the yast2_http,yast2-dns-server and yast2-dhcp-server will be removed from yast2_ncurses.yaml, to reserve these yast2 test in leap job group we create a new yaml schedule copied from yast2_ncurses.yaml for leap.

Related ticket: https://progress.opensuse.org/issues/124433
Related PR:  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16580
