### PR TITLE
set flavor as DVD-Updates

### DIFF
--- a/job_groups/support_images.yaml
+++ b/job_groups/support_images.yaml
@@ -13,20 +13,18 @@ defaults:
     machine: 64bit
     priority: 40
 products:
-  opensuse-15.4-DVD-x86_64:
+  opensuse-15.4-DVD-Updates-x86_64:
     distri: opensuse
-    # Select DVD flavor while not DVD-Updates to less frequency for auto-generate support images.
-    flavor: DVD
+    flavor: DVD-Updates
     version: '15.4'
 scenarios:
   x86_64:
-    opensuse-15.4-DVD-x86_64:
+    opensuse-15.4-DVD-Updates-x86_64:
       - create_hdd_leap_gnome_autoyast_updated:
           testsuite: null
           settings:
             DESKTOP: gnome
             HDDSIZEGB: "30"
-            ISO: openSUSE-Leap-15.0-DVD-x86_64.iso
             OS_TEST_ISSUES: ""
             PUBLISH_HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
             PUBLISH_PFLASH_VARS: "opensuse-leap-updated-%ARCH%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"


### PR DESCRIPTION
We can't find a suitable flavor to reduce frequency, so we need set the flavor as DVD-Updates.

Related ticket: https://progress.opensuse.org/issues/122173

VR: https://openqa.opensuse.org/tests/3164690#