### PR TITLE
Fix QEMU virtualization test suite for leap-micro

### DIFF
--- a/job_groups/opensuse_leap_micro_5.x_image.yaml
+++ b/job_groups/opensuse_leap_micro_5.x_image.yaml
@@ -46,6 +46,7 @@
 .image_qemu_settings: &image_qemu_settings
   <<: *image_settings
   QEMUCPU: 'host'
+  EXTRA: 'virtualization'
 
 defaults:
   x86_64:


### PR DESCRIPTION
Add `EXTRA=virtualization` in order to load proper test cases for this test suite.