### PR TITLE
Replace influxdb by postgres

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -930,7 +930,8 @@ scenarios:
           machine: 64bit_virtio
           priority: 48
           settings:
-            INFLUXDB_SERVER: '18.196.183.86'
+            POSTGRES_IP: 'k2.qe.suse.de'
+            POSTGRES_PORT: '8080'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:


### PR DESCRIPTION
Update image monitoring server variables as InfluxDB has been replaced by postgres.