### PR TITLE
ALP: Add KEEP_GRUB_TIMEOUT to aarch64 jobs

### DIFF
--- a/job_groups/alp_bedrock.yaml
+++ b/job_groups/alp_bedrock.yaml
@@ -90,6 +90,8 @@ defaults:
   aarch64:
     machine: aarch64
     priority: 50
+    settings:
+      KEEP_GRUB_TIMEOUT: "1"
 
 products:
   alp-bedrock-0.1-Default-x86_64:

--- a/job_groups/alp_micro.yaml
+++ b/job_groups/alp_micro.yaml
@@ -94,6 +94,8 @@ defaults:
   aarch64:
     machine: aarch64
     priority: 50
+    settings:
+      KEEP_GRUB_TIMEOUT: "1"
 
 products:
   alp-micro-0.1-Default-x86_64:


### PR DESCRIPTION
https://openqa.opensuse.org/tests/3186286
vs
https://openqa.opensuse.org/tests/3186590