### PR TITLE
Remove k3s test from ALP Bedrock

### DIFF
--- a/job_groups/alp_bedrock.yaml
+++ b/job_groups/alp_bedrock.yaml
@@ -80,9 +80,6 @@
 .ltp_containers: &ltp_containers
   LTP_COMMAND_FILE: 'containers'
 
-.k3s: &k3s
-  CONTAINER_RUNTIME: 'k3s'
-
 .selinux_settings: &selinux_settings
   ENABLE_SELINUX: '1'
   EXTRA: 'selinux'
@@ -153,10 +150,6 @@ scenarios:
           settings:
             <<: [*ltp, *ltp_containers]
           testsuite: null
-      - k3s:
-          testsuite: null
-          settings:
-            <<: [*image_settings, *k3s]
       - selinux:
           settings:
             <<: [*image_settings, *selinux_settings]
@@ -212,10 +205,6 @@ scenarios:
           settings:
             <<: [*ltp, *ltp_containers]
           testsuite: null
-      - k3s:
-          testsuite: null
-          settings:
-            <<: [*image_settings, *k3s]
       - selinux:
           settings:
             <<: [*image_settings, *selinux_settings]


### PR DESCRIPTION
Bedrock is more the server flavor and it won't contain the k3s-install binary as ALP Micro does.