### PR TITLE
schedule  kea dhcp container test in ALP

### DIFF
--- a/job_groups/alp_micro.yaml
+++ b/job_groups/alp_micro.yaml
@@ -160,6 +160,10 @@ scenarios:
           settings:
             <<: [*image_settings, *selinux_settings]
           testsuite: null
+      - kea_dhcp4_container_server
+      - kea_dhcp4_container_client
+      - kea_dhcp6_container_server
+      - kea_dhcp6_container_client
     alp-micro-0.1-Default-qcow-x86_64:
       - alp_default:
           machine: [64bit, uefi]


### PR DESCRIPTION

Related ticket: https://progress.opensuse.org/issues/124209
Needles: NO
Verification run: 
I verified in the developement job group in O3: https://openqa.opensuse.org/tests/overview?distri=alp&version=micro-0.1&build=3.5&groupid=93.  