### PR TITLE
opensuse_tumbleweed_aarch64: Add missing CONTAINERS_UNTESTED_IMAGES=1

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -266,6 +266,7 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIME: 'docker,podman'
+            CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             # Temporarily disabled due to db instance being down
             IMAGE_STORE_DATA: '0'


### PR DESCRIPTION
Without this it ran an entirely different schedule.