### PR TITLE
Tumbleweed: aarch64: migrate RPi3 jeos-containers to jeos-container_{host,image}

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -543,6 +543,8 @@ scenarios:
           machine: aarch64-HD20G
       - jeos-container_image:
           machine: aarch64-HD20G
+          settings:
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
       - jeos-filesystem:
           machine: aarch64-HD20G
       - jeos-fips:
@@ -573,6 +575,17 @@ scenarios:
           machine: RPi4
           settings:
             PASSWORD: linux
+      - jeos-container_host:
+          machine: RPi3
+          settings:
+            PASSWORD: linux
+            TIMEOUT_SCALE: '3'
+      - jeos-container_image:
+          machine: RPi3
+          settings:
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
+            PASSWORD: linux
+            TIMEOUT_SCALE: '3'
       - jeos-containers:
           machine: RPi3
           settings:


### PR DESCRIPTION
as done for x86_64