### PR TITLE
Move kea workload container test from ALP micro to ALP bedrock

### DIFF
--- a/job_groups/alp_bedrock.yaml
+++ b/job_groups/alp_bedrock.yaml
@@ -154,6 +154,10 @@ scenarios:
           settings:
             <<: [*image_settings, *selinux_settings]
           testsuite: null
+      - kea_dhcp4_container_server
+      - kea_dhcp4_container_client
+      - kea_dhcp6_container_server
+      - kea_dhcp6_container_client
       - container_selinux:
           settings:
             <<: *image_settings

--- a/job_groups/alp_micro.yaml
+++ b/job_groups/alp_micro.yaml
@@ -160,10 +160,6 @@ scenarios:
           settings:
             <<: [*image_settings, *selinux_settings]
           testsuite: null
-      - kea_dhcp4_container_server
-      - kea_dhcp4_container_client
-      - kea_dhcp6_container_server
-      - kea_dhcp6_container_client
       - container_selinux:
           settings:
             <<: *image_settings


### PR DESCRIPTION
Realted to [poo#124209](https://progress.opensuse.org/issues/124209)

After the discussion, it was decided to schedule the container workload tests in ALP bedrock.

VRs: [DHCP4_client](https://openqa.opensuse.org/tests/3260879#l) | [DHCP4_server](https://openqa.opensuse.org/tests/3260878#)
        [DHCP6_client](https://openqa.opensuse.org/tests/3260881#) | [DHCP6_server](https://openqa.opensuse.org/tests/3260880#)