### PR TITLE
[ WIP] kernel/s390x: Add and ltp_net_nfs

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -247,6 +247,7 @@ scenarios:
     opensuse-Tumbleweed-DVD-s390x:
       - ltp_cve
       - ltp_crypto_pty_commands
+      - ltp_net_nfs
       - ltp_syscalls
       - kernel-live-patching:
           settings:


### PR DESCRIPTION
Verification run:
- ltp_net_nfs https://openqa.opensuse.org/tests/3275806 ([nfslock3t_01](https://openqa.opensuse.org/tests/3275806/modules/nfslock3t_01/steps/1/src) and [nfslock3t_ipv6_01](https://openqa.opensuse.org/tests/3275806/modules/nfslock3t_ipv6_01/steps/1/src) is [upstream issue](https://lore.kernel.org/ltp/20230504203707.GA3830225@pevik/) and filtered out in our testsuite.