### PR TITLE
Add data for lvm_raid1 Tumbleweed

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -217,7 +217,9 @@ scenarios:
       - create_hdd_gnome_wicked
       - create_hdd_kde:
           priority: 45
-      - lvm+RAID1
+      - lvm+RAID1:
+          settings:
+            YAML_TEST_DATA: test_data/yast/opensuse/lvm+raid1.yaml
       - boot_to_snapshot
       - yast2_firstboot
       - yast2_firstboot_custom


### PR DESCRIPTION
https://openqa.opensuse.org/tests/3278116
We need to first merge this PR for the checks to pass:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17034