### PR TITLE
Revert "Add data for lvm_raid1 Tumbleweed"

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -217,9 +217,7 @@ scenarios:
       - create_hdd_gnome_wicked
       - create_hdd_kde:
           priority: 45
-      - lvm+RAID1:
-          settings:
-            YAML_TEST_DATA: test_data/yast/opensuse/lvm+raid1.yaml
+      - lvm+RAID1
       - boot_to_snapshot
       - yast2_firstboot
       - yast2_firstboot_custom


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#324

The raid1 update is now on Tumbleweed as well so there is no need for separate test data.
https://progress.opensuse.org/issues/128678