### PR TITLE
Revert "Change schedule for RAID1_gpt leap"

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -79,8 +79,6 @@ scenarios:
           machine: 64bit
       - RAID1_gpt:
           machine: 64bit
-          settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/raid/raid1_gpt_leap.yaml
       - RAID5_gpt:
           machine: 64bit
           settings:


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#321


The raid1 update is now on Tumbleweed as well so there is no need for separate test data or schedule.
https://progress.opensuse.org/issues/128678