### PR TITLE
Revert "Change schedule for RAID1_gpt Staging"

### DIFF
--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -100,8 +100,6 @@ scenarios:
       - RAID0_gpt
       - RAID1_gpt:
           machine: 64bit
-          settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/raid/raid1_gpt_leap.yaml
     opensuse-Core-Staging-DVD-x86_64:
       - textmode:
           machine: 64bit
@@ -124,8 +122,6 @@ scenarios:
       # - lvm+RAID1
       - RAID1_gpt:
           machine: 64bit
-          settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/raid/raid1_gpt_leap.yaml
     opensuse-*-Staging-JeOS-for-kvm-and-xen-x86_64:
       - jeos:
           machine: uefi-staging-virtio-2G


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#323

The raid1 update is now on Tumbleweed as well so there is no need for separate test data or schedule.
https://progress.opensuse.org/issues/128678