### PR TITLE
Add workaround for boo1211459

### DIFF
--- a/job_groups/opensuse_leap_15.4_backports.yaml
+++ b/job_groups/opensuse_leap_15.4_backports.yaml
@@ -8,6 +8,8 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #       job_groups/opensuse_leap_15.4_backports.yaml       #
 ############################################################
+.boo1211459: &boo1211459
+  EXCLUDE_MODULES: force_scheduled_tasks
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -22,20 +24,29 @@ scenarios:
     opensuse-15.4-DVD-Backports-Incidents-x86_64:
       - textmode:
           machine: 64bit
-      - kde
+          settings:
+            <<: *boo1211459
+      - kde:
+          settings:
+            <<: *boo1211459
       - gnome:
           machine: uefi
           settings:
+            <<: *boo1211459
             QEMUVGA: cirrus
       - gnome:
           machine: 64bit-2G
           settings:
+            <<: *boo1211459
             QEMUVGA: cirrus
       - cryptlvm:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
       - install_with_updates_gnome:
           settings:
+            <<: *boo1211459
             QEMUVGA: cirrus
       - install_with_updates_kde:
           machine: uefi-2G
+          settings:
+            <<: *boo1211459

--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -39,7 +39,10 @@ scenarios:
       - autoyast_leap_videomode_text
       - create_hdd_leap_gnome_autoyast
       - create_hdd_leap_kde_autoyast
-      - create_hdd_leap_textmode_autoyast
+      - create_hdd_leap_textmode_autoyast:
+          settings:
+            # Workaround for boo#1211459 [Leap 15.4 only]
+            EXCLUDE_MODULES: force_scheduled_tasks
       - create_hdd_leap_transactional_server_autoyast
       - create_hdd_leap_gnome_uefi_autoyast:
           machine: 'uefi'
@@ -175,6 +178,8 @@ scenarios:
             # *console/zypper_{ar,ref}* replaced by console/zypper_add_repos
             # *transactional/install_updates* to apply updates on transactional system
             +YAML_SCHEDULE: ''
+            # Workaround for boo#1211459 [Leap 15.4 only]
+            EXCLUDE_MODULES: force_scheduled_tasks
       - extra_tests_transactional_server:
           testsuite: 'extra_tests_transactional_server'
           settings:


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1211459
https://progress.opensuse.org/issues/129358
https://progress.opensuse.org/issues/129289

**We can skip `force_scheduled_tasks` as a temporary workaround**
VR:
 [leap15.4 backports](http://bassey.arch.nue2.suse.org/tests/24)
 [Leap15.4 update snapper](https://openqa.opensuse.org/tests/overview?version=15.4&distri=opensuse&build=rfan0522)
 [Leap 15.4 update transactional_server](https://openqa.opensuse.org/tests/3306817#)