### PR TITLE
Revert "Add workaround for boo1211459"

### DIFF
--- a/job_groups/opensuse_leap_15.4_backports.yaml
+++ b/job_groups/opensuse_leap_15.4_backports.yaml
@@ -8,8 +8,6 @@
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
 #       job_groups/opensuse_leap_15.4_backports.yaml       #
 ############################################################
-.boo1211459: &boo1211459
-  EXCLUDE_MODULES: force_scheduled_tasks
 defaults:
   x86_64:
     machine: 64bit-2G
@@ -24,29 +22,20 @@ scenarios:
     opensuse-15.4-DVD-Backports-Incidents-x86_64:
       - textmode:
           machine: 64bit
-          settings:
-            <<: *boo1211459
-      - kde:
-          settings:
-            <<: *boo1211459
+      - kde
       - gnome:
           machine: uefi
           settings:
-            <<: *boo1211459
             QEMUVGA: cirrus
       - gnome:
           machine: 64bit-2G
           settings:
-            <<: *boo1211459
             QEMUVGA: cirrus
       - cryptlvm:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
       - install_with_updates_gnome:
           settings:
-            <<: *boo1211459
             QEMUVGA: cirrus
       - install_with_updates_kde:
           machine: uefi-2G
-          settings:
-            <<: *boo1211459

--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -39,10 +39,7 @@ scenarios:
       - autoyast_leap_videomode_text
       - create_hdd_leap_gnome_autoyast
       - create_hdd_leap_kde_autoyast
-      - create_hdd_leap_textmode_autoyast:
-          settings:
-            # Workaround for boo#1211459 [Leap 15.4 only]
-            EXCLUDE_MODULES: force_scheduled_tasks
+      - create_hdd_leap_textmode_autoyast
       - create_hdd_leap_transactional_server_autoyast
       - create_hdd_leap_gnome_uefi_autoyast:
           machine: 'uefi'
@@ -178,8 +175,6 @@ scenarios:
             # *console/zypper_{ar,ref}* replaced by console/zypper_add_repos
             # *transactional/install_updates* to apply updates on transactional system
             +YAML_SCHEDULE: ''
-            # Workaround for boo#1211459 [Leap 15.4 only]
-            EXCLUDE_MODULES: force_scheduled_tasks
       - extra_tests_transactional_server:
           testsuite: 'extra_tests_transactional_server'
           settings:


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#331

Even the workaround can work fine in my private tests.
But as @DimStar77 mentioned, I can see new issues:

`imho this carries the risk that the scheduled tasks are now running at random times, uncontrolled.This in turn can have a negative impact on the reproducibility of issues, as performance can be impacted whenever those scheduled tasks fire off `