### PR TITLE
sway: Avoid HDD_1 mismatch by setting virtio-vga directly

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -650,11 +650,11 @@ scenarios:
       - create_hdd_gnome-wayland
       - sway:
           testsuite: null
-          machine: 64bit_virtio
           settings:
             BOOT_HDD_IMAGE: "1"
             VIDEOMODE: text
             DESKTOP: textmode
+            QEMU_VIDEO_DEVICE: virtio-vga
             HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
             UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
             START_AFTER_TEST: create_hdd_textmode

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -614,11 +614,11 @@ scenarios:
           priority: 45
       - sway:
           testsuite: null
-          machine: 64bit_virtio
           settings:
             BOOT_HDD_IMAGE: "1"
             VIDEOMODE: text
             DESKTOP: textmode
+            QEMU_VIDEO_DEVICE: virtio-vga
             HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
             UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
             START_AFTER_TEST: create_hdd_textmode


### PR DESCRIPTION
Setting the machine changes the name of the HDD_1 asset to something that doesn't exist. We don't run create_hdd_textmode on the 64bit_virtio machine and we don't need to.

We can change QEMU_VIDEO_DEVICE and the VM image still works OK.

Fixes: #341 

@DimStar77 