### PR TITLE
kernel: Run NFS tests also on aarch64 and ppc64le

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -141,6 +141,49 @@ scenarios:
       - xfstests_nfs4.0-nfs
       - xfstests_nfs3-generic
       - xfstests_nfs3-nfs
+      - nfs_server:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            NICTYPE: tap
+            HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
+            UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
+            PARALLEL_WITH: nfs_support_server
+            ROLE: nfs_server
+            HOSTNAME: server-node00
+            USE_SUPPORT_SERVER: "1"
+            YAML_SCHEDULE: schedule/storage/nfs.yaml
+      - nfs_client:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            NICTYPE: tap
+            HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
+            UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
+            PARALLEL_WITH: nfs_support_server
+            ROLE: nfs_client
+            HOSTNAME: client-node00
+            USE_SUPPORT_SERVER: "1"
+            YAML_SCHEDULE: schedule/storage/nfs.yaml
+      - nfs_support_server:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            EXTRABOOTPARAMS_BOOT_LOCAL: "3"
+            SUPPORT_SERVER: "1"
+            SUPPORT_SERVER_ROLES: dhcp,dns
+            NICTYPE: tap
+            VIDEOMODE: text
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            HDD_1: "support_server_tumbleweed@64bit.qcow2"
+            START_AFTER_TEST: create_hdd_textmode
+            YAML_SCHEDULE: schedule/storage/supportserver.yaml
+            MULTIMACHINE_NODES: "2"
   i586:
     opensuse-Tumbleweed-LegacyX86-NET-i586:
       - install_ltp+opensuse+LegacyX86-NET
@@ -243,6 +286,49 @@ scenarios:
       - xfstests_nfs4.0-nfs
       - xfstests_nfs3-generic
       - xfstests_nfs3-nfs
+      - nfs_server:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            NICTYPE: tap
+            HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
+            UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
+            PARALLEL_WITH: nfs_support_server
+            ROLE: nfs_server
+            HOSTNAME: server-node00
+            USE_SUPPORT_SERVER: "1"
+            YAML_SCHEDULE: schedule/storage/nfs.yaml
+      - nfs_client:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            NICTYPE: tap
+            HDD_1: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2"
+            UEFI_PFLASH_VARS: "%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2"
+            PARALLEL_WITH: nfs_support_server
+            ROLE: nfs_client
+            HOSTNAME: client-node00
+            USE_SUPPORT_SERVER: "1"
+            YAML_SCHEDULE: schedule/storage/nfs.yaml
+      - nfs_support_server:
+          testsuite: null
+          settings:
+            BOOT_HDD_IMAGE: "1"
+            EXTRABOOTPARAMS_BOOT_LOCAL: "3"
+            SUPPORT_SERVER: "1"
+            SUPPORT_SERVER_ROLES: dhcp,dns
+            NICTYPE: tap
+            VIDEOMODE: text
+            DESKTOP: "textmode"
+            WORKER_CLASS: tap
+            HDD_1: "support_server_tumbleweed@64bit.qcow2"
+            START_AFTER_TEST: create_hdd_textmode
+            YAML_SCHEDULE: schedule/storage/supportserver.yaml
+            MULTIMACHINE_NODES: "2"
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
       - ltp_cve


### PR DESCRIPTION
Run nfs_client, nfs_server, nfs_support_server on aarch64 and ppc64le. Not run on s390x, because we run only minimal tests on it.

@schlad FYI