### PR TITLE
Increase ram for OBS Unstable

### DIFF
--- a/job_groups/obs_unstable.yaml
+++ b/job_groups/obs_unstable.yaml
@@ -20,4 +20,6 @@ products:
 scenarios:
   x86_64:
     obs-Unstable-Appliance-x86_64:
-      - obs_appliance
+      - obs_appliance:
+          settings:
+            QEMURAM: '8192'


### PR DESCRIPTION
OBS Unstable currently encounters oom killer in every run, so we need more memory. This is intended to help