### PR TITLE
Fix raid_gpt RAID0 case

### DIFF
--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -404,6 +404,10 @@ scenarios:
       - gnome
       - minimalx:
           machine: ppc64le
+      - RAID0:
+          settings:
+            YAML_SCHEDULE: schedule/yast/opensuse/raid/raid0_gpt.yaml
+            YAML_TEST_DATA: test_data/yast/raid/raid0_prep_boot_opensuse15.4.yaml
       - gpt
       - create_hdd_textmode:
           settings:


### PR DESCRIPTION
Add chunk size for RAID1 opensuse15.4 test_data
Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17479