### PR TITLE
opensuse_leap_15.4_images: Run autoyast_minimal on aarch64

### DIFF
--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -381,6 +381,7 @@ scenarios:
           settings:
             QEMU_VIRTIO_RNG: "0"
       - autoyast_minimal:
+          machine: aarch64
           settings:
             AUTOYAST: autoyast_opensuse/opensuse_leap_minimal.xml
       - package-dependency:


### PR DESCRIPTION
The workaround for https://bugzilla.suse.com/show_bug.cgi?id=1022064 is needed but that's not present in the autoyast schedule, so place it on a machine type which does not require it.

Verification run (cloned with `USBBOOT=0`): https://openqa.opensuse.org/tests/3456215