### PR TITLE
Tumbleweed: run GNOME/Live tests on USBBOT_64 with 3GB of RAM

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -921,7 +921,7 @@ scenarios:
           machine: 64bit-4G
           priority: 48
       - gnome-live:
-          machine: USBboot_64-2G
+          machine: USBboot_64-3G
           priority: 48
       - gnome-live:
           machine: uefi-usb-4G


### PR DESCRIPTION
https://progress.opensuse.org/issues/135197
