### PR TITLE
Move 2 virtualization tests from Development Tumbleweed Job group to openSUSE Tumbleweed Job group for daily review

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -911,6 +911,10 @@ scenarios:
             DESKTOP: textmode
             AUTOYAST: 'autoyast_opensuse/create_hdd/create_hdd_textmode_x86_64_uefi.xml'
       - sys-param-check
+      - virt-guest-installation-kvm:
+          machine: 64bit-ipmi
+      - virt-guest-installation-xen:
+          machine: 64bit-ipmi
     opensuse-Tumbleweed-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi
@@ -933,7 +937,6 @@ scenarios:
           machine: 64bit_virtio
           priority: 48
           settings:
-            #POSTGRES_IP: 'k2.qe.suse.de'
             POSTGRES_IP: '10.137.0.6'
             POSTGRES_PORT: '8080'
       - jeos:


### PR DESCRIPTION
Description
-- To add "[virtualization][factory-first] deploy guest installation tests" to the "O3 official job group" due to their consistently high pass ratio.
-- There are two tests from the virtualization [qe-virt] team with IPMI backends.
-- Tests virt-guest-installation-kvm@64bit-ipmi and virt-guest-installation-xen@64bit-ipmi

- Related ticket: https://progress.opensuse.org/issues/103742
- Latest runs: [KVM](https://openqa.opensuse.org/tests/3569884#next_previous) (Failed in past due to [BUG](https://bugzilla.suse.com/show_bug.cgi?id=1214592) [Resolved]) and [XEN](https://openqa.opensuse.org/tests/3568962#next_previous) (Failed in past due to [BUG](https://bugzilla.suse.com/show_bug.cgi?id=1212132) [Resolved])

https://openqa.opensuse.org/tests/3583693# KVM
https://openqa.opensuse.org/tests/3583691# XEN

Welcome review!
Thanks :)
@Julie-CAO @guoxuguang @waynechen55 @alice-suse @RoyCai7 @tonyyuan1 @tbaev @nanzhg



