### PR TITLE
Fix Leap Micro 5.5 container test

### DIFF
--- a/job_groups/opensuse_leap_micro_5.x_image.yaml
+++ b/job_groups/opensuse_leap_micro_5.x_image.yaml
@@ -25,7 +25,7 @@
   SKIP_DOCKER_IMAGE_TESTS: '1'
   REGISTRY: '3.71.98.16:5000'
   CONTAINER_RUNTIME: 'podman'
-  CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap:15.5'
+  CONTAINER_IMAGE_VERSIONS: '15.4,15.5'
 
 .selfinstall_settings: &selfinstall_settings
   <<: *default_settings


### PR DESCRIPTION
CONTAINER_IMAGE_VERSIONS instead of CONTAINER_IMAGE_TO_TEST will make that it doesn't check the current os distri, but instead read it from
https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/lib/containers/urls.pm

VR: https://openqa.opensuse.org/tests/3589199