### PR TITLE
opensuse_tumbleweed.yaml: Add missing NUMDISKS=3 to jeos-combustion

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -950,6 +950,7 @@ scenarios:
           settings:
             FIRST_BOOT_CONFIG: 'combustion'
             HDD_2: 'extended_combustion.qcow2'
+            NUMDISKS: '3'
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:


### PR DESCRIPTION
VR: https://openqa.opensuse.org/tests/3604572