### PR TITLE
Tumbleweed: aarch64: Drop jeos-containers test

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -586,11 +586,6 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             PASSWORD: linux
             TIMEOUT_SCALE: '3'
-      - jeos-containers:
-          machine: RPi3
-          settings:
-            PASSWORD: linux
-            TIMEOUT_SCALE: '3'
       - jeos:
           machine: RPi4
           settings:


### PR DESCRIPTION
as it is split in 2 test: jeos-container_{host,image}