### PR TITLE
opensuse_tumbleweed.yaml: disable gnome test on 64bit_cirrus

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -154,9 +154,9 @@ scenarios:
       - gnome:
           machine: 64bit
           priority: 45
-      - gnome:
-          machine: 64bit_cirrus
-          priority: 45
+#      - gnome:
+#          machine: 64bit_cirrus
+#          priority: 45
       - minimalx:
           machine: 64bit
           priority: 45


### PR DESCRIPTION
This is causing too many failures at this moment to be useful.