### PR TITLE
tumbleweed: do not run ipmi based baremetal tests for now

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -925,10 +925,10 @@ scenarios:
             DESKTOP: textmode
             AUTOYAST: 'autoyast_opensuse/create_hdd/create_hdd_textmode_x86_64_uefi.xml'
       - sys-param-check
-      - virt-guest-installation-kvm:
-          machine: 64bit-ipmi
-      - virt-guest-installation-xen:
-          machine: 64bit-ipmi
+#      - virt-guest-installation-kvm:
+#          machine: 64bit-ipmi
+#      - virt-guest-installation-xen:
+#          machine: 64bit-ipmi
     opensuse-Tumbleweed-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi


### PR DESCRIPTION
With the DC migration, there are curretnly no workers available that
can handle this and the tests need to be cancelled every day

https://progress.opensuse.org/issues/132647
