### PR TITLE
opensuse_tumbleweed.yaml: Add microos-sdboot test

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -75,6 +75,8 @@ scenarios:
       - microos_10G-disk
       - microos:
           machine: uefi
+      - microos-sdboot:
+          machine: uefi
       - microos:
           machine: 64bit
       - microos_textmode


### PR DESCRIPTION
After the latest PR it appears stable:

https://openqa.opensuse.org/tests/3667342
https://openqa.opensuse.org/tests/3667343
https://openqa.opensuse.org/tests/3667344

CC @ana (not in the list of selectable assignees)