### PR TITLE
Split io_uring, bpftrace and bcc test modules from kernel extra tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -57,6 +57,8 @@ scenarios:
   aarch64:
     opensuse-Tumbleweed-DVD-aarch64:
       - extra_tests_kernel
+      - bpftools
+      - io_uring
       - kdump:
           settings:
             CRASH_MEMORY: '320'
@@ -201,6 +203,8 @@ scenarios:
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
       - extra_tests_kernel
+      - bpftools
+      - io_uring
       - kdump:
           settings:
             CRASH_MEMORY: '640'
@@ -341,6 +345,8 @@ scenarios:
   x86_64:
     opensuse-Tumbleweed-DVD-x86_64:
       - extra_tests_kernel
+      - bpftools
+      - io_uring
       - kdump
       - install_ltp+opensuse+DVD
       - kernel-live-patching


### PR DESCRIPTION
These tests modules are so far scheduled via the test suite `extra_tests_kernel` that is run within the "openSUSE Tumbleweed Kernel" job group. This change moves these test modules to their own test suites `io_uring` and `bpftools` which have been created on o3.

Related ticket: https://progress.opensuse.org/issues/138407