### PR TITLE
Add MicroOS-Image-sdboot

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -39,6 +39,10 @@ products:
     distri: microos
     flavor: MicroOS-Image
     version: Tumbleweed
+  microos-*-MicroOS-Image-sdboot-x86_64:
+    distri: microos
+    flavor: MicroOS-Image-sdboot
+    version: Tumbleweed
   microos-*-MicroOS-SelfInstall-x86_64:
     distri: microos
     flavor: MicroOS-SelfInstall
@@ -123,6 +127,11 @@ scenarios:
           settings:
             QEMUCPU: 'host'
       - microos_fips
+    microos-*-MicroOS-Image-sdboot-x86_64:
+      - microos-combustion:
+          machine: uefi
+      - microos-wizard:
+          machine: uefi
     microos-*-MicroOS-SelfInstall-x86_64:
       - microos
     opensuse-Tumbleweed-DVD-x86_64:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -70,6 +70,10 @@ products:
     distri: microos
     flavor: MicroOS-Image
     version: Tumbleweed
+  microos-*-MicroOS-Image-sdboot-aarch64:
+    distri: microos
+    flavor: MicroOS-Image-sdboot
+    version: Tumbleweed
   opensuse-Tumbleweed-NET-armv7hl:
     distri: opensuse
     flavor: NET
@@ -134,6 +138,9 @@ scenarios:
           settings:
             EXCLUDE_MODULES: kvm
       - microos_fips
+    microos-*-MicroOS-Image-sdboot-aarch64:
+      - microos-combustion
+      - microos-wizard
     opensuse-Tumbleweed-DVD-aarch64:
       - security_tpm2
       - unlock_luks2_volume_with_tpm2:


### PR DESCRIPTION
Tests look stable: https://openqa.opensuse.org/tests/overview?distri=microos&version=Tumbleweed&build=20231025&groupid=38&flavor=MicroOS-Image-sdboot