### PR TITLE
staging_projects.yaml: Remove redundant microos_textmode test

### DIFF
--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -130,7 +130,6 @@ scenarios:
     microos-*-Staging-MicroOS-Image-ContainerHost-x86_64:
       - microos:
           machine: 64bit
-      - microos_textmode
       - container-host:
           machine: 64bit
           settings:


### PR DESCRIPTION
The _textmode variant only makes sense for DVD installs.