### PR TITLE
Use kubectl from k3s installation script

### DIFF
--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -153,8 +153,6 @@ scenarios:
             CONTAINER_RUNTIME: 'podman'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
-            K3S_SYMLINK: 'skip'
-            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_kubectl_containers:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_leap_15.5_updates.yaml
+++ b/job_groups/opensuse_leap_15.5_updates.yaml
@@ -134,8 +134,6 @@ scenarios:
             CONTAINER_RUNTIME: 'podman'
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
-            K3S_SYMLINK: 'skip'
-            K8S_CLIENT: 'kubernetes1.24-client'
       - extra_tests_textmode_kubectl_containers:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
`podman_pods` were failing in Leap testing due to missing `kubectl` binary. As the module does not pull kube client from repo, it depends on k3s provided binary. Remove skip option to create a symlink for kubectl

- ticket:https://progress.opensuse.org/issues/138425