### PR TITLE
kernel: Remove ltp_fsx

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -86,7 +86,6 @@ scenarios:
       - ltp_fs_bind
       - ltp_fs_perms_simple
       - ltp_fs_readonly
-      - ltp_fsx
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
@@ -232,7 +231,6 @@ scenarios:
       - ltp_fs_bind
       - ltp_fs_perms_simple
       - ltp_fs_readonly
-      - ltp_fsx
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
@@ -372,7 +370,6 @@ scenarios:
       - ltp_fs_bind
       - ltp_fs_perms_simple
       - ltp_fs_readonly
-      - ltp_fsx
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima


### PR DESCRIPTION
This runtest file was removed in current LTP master:
https://github.com/linux-test-project/ltp/commit/fb2b6a0b3c840aa80229acf4360b7bdc3ced5e