### PR TITLE
Re-add "kernel: Remove udev-no-partlabel-links"

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -421,6 +421,7 @@ scenarios:
       - nfs_cthon04-nfs4
       - nfs_pynfs_nfs40_all
       - nfs_pynfs_nfs41_all
+      - udev-no-partlabel-links
       - create_hdd_xfstests
       - xfstests_btrfs-btrfs-001-100
       - xfstests_btrfs-btrfs-101-200


### PR DESCRIPTION
Test was written for testing bsc#1089761 (SLE 12-SP3), thus it was removed. pcervinka asked to add it back.

Suggested-by: Petr Cervinka <pcervinka@suse.com>

@czerw Added as your request. Please remove [WIP] and merge if you plan to maintain this in Tumbleweed.