### PR TITLE
Revert "Add job for testing cgroup v1 on docker"

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -276,11 +276,6 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'docker'
-      - containers_host_docker_cgroupv1:
-          testsuite: extra_tests_textmode_containers
-          settings:
-            CONTAINER_RUNTIMES: 'docker'
-            CONTAINERS_CGROUP_VERSION: '1'
       - containers_host_podman:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -230,11 +230,6 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'docker'
-      - containers_host_docker_cgroupv1:
-          testsuite: extra_tests_textmode_containers
-          settings:
-            CONTAINER_RUNTIMES: 'docker'
-            CONTAINERS_CGROUP_VERSION: '1'
       - containers_host_helm:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -71,11 +71,6 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'docker'
-      - containers_host_docker_cgroupv1:
-          testsuite: extra_tests_textmode_containers
-          settings:
-            CONTAINER_RUNTIMES: 'docker'
-            CONTAINERS_CGROUP_VERSION: '1'
       - containers_host_podman:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
The next systemd version will drop support for cgroup v1:

https://github.com/systemd/systemd/blob/main/NEWS#L17

This reverts commit 46600709baf91370672b9960c4fcb79898062db5.