### PR TITLE
New test for checking systemd in WSL

### DIFF
--- a/job_groups/opensuse_leap_15.6_wsl.yaml
+++ b/job_groups/opensuse_leap_15.6_wsl.yaml
@@ -36,7 +36,7 @@ scenarios:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
-      - wsl2-main:
+      - wsl2-main: &wsl2_defaults
           testsuite: null
           machine: [win10_64bit, win10_uefi, win11_uefi]
           settings:
@@ -49,18 +49,16 @@ scenarios:
             WORKER_CLASS: 'wsl2'
       # to be re-enabled after GA, when 15.6 is available in the Store.
       # - wsl2-install-msstore:
-      #     testsuite: null
-      #     machine: [win10_64bit, win10_uefi, win11_uefi]
+      #     <<: *wsl2_defaults
       #     description: |
       #       Basic WSL test Test scope:
       #           1) Prepare WSL and other features in Windows
-      #           2) Download the winget utility and install it
-      #           3) Install WSL image from the MS Store via CLI
+      #           2) Install WSL image from the MS Store via CLI
       #     settings:
-      #       YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
-      #       WSL2: '1'
-      #       QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
-      #       QEMUMACHINE: 'q35,accel=whpx'
-      #       WORKER_CLASS: 'wsl2'
       #       WSL_VERSION: 'openSUSE Leap 15.6'
       #       WSL_INSTALL_FROM: 'msstore'
+      - wsl2-systemd:
+          <<: *wsl2_defaults
+          description: 'Enable and test systemd in WSL'
+          settings:
+            WSL_SYSTEMD: '1'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1138,7 +1138,7 @@ scenarios:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
-      - wsl2-main:
+      - wsl2-main: &wsl2_defaults
           testsuite: null
           machine: [win10_64bit, win10_uefi, win11_uefi]
           settings:
@@ -1150,18 +1150,16 @@ scenarios:
             QEMUMACHINE: 'q35,accel=whpx'
             WORKER_CLASS: 'wsl2'
       - wsl2-install-msstore:
-          testsuite: null
-          machine: [win10_64bit, win10_uefi, win11_uefi]
+          <<: *wsl2_defaults
           description: |
             Basic WSL test Test scope:
                 1) Prepare WSL and other features in Windows
-                2) Download the winget utility and install it
-                3) Install WSL image from the MS Store via CLI
+                2) Install WSL image from the MS Store via CLI
           settings:
-            YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
-            WSL2: '1'
-            QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
-            QEMUMACHINE: 'q35,accel=whpx'
-            WORKER_CLASS: 'wsl2'
             WSL_VERSION: 'openSUSE Tumbleweed'
             WSL_INSTALL_FROM: 'msstore'
+      - wsl2-systemd:
+          <<: *wsl2_defaults
+          description: 'Enable and test systemd in WSL'
+          settings:
+            WSL_SYSTEMD: '1'


### PR DESCRIPTION
WSL now supports systemd, so there's need to check that we can enable and test it

- Paired with: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/17670
- Related ticket: [poo#133691](https://progress.opensuse.org/issues/133691)
- Needles: *not_needed*
- Verification runs:
  - SLE:
    - https://openqa.suse.de/tests/12855059
    - https://openqa.suse.de/tests/12867495
    - https://openqa.suse.de/tests/12855057
    - https://openqa.suse.de/tests/12867496
    - https://openqa.suse.de/tests/12855055
    - https://openqa.suse.de/tests/12867497
  - TW:
    - https://openqa.opensuse.org/tests/3744420
    - https://openqa.opensuse.org/tests/3747994
    - https://openqa.opensuse.org/tests/3744422
    - https://openqa.opensuse.org/tests/3747995
    - https://openqa.opensuse.org/tests/3744424
    - https://openqa.opensuse.org/tests/3800853
  - Leap:
    - https://openqa.opensuse.org/tests/3800615
    - https://openqa.opensuse.org/tests/3800635
    - https://openqa.opensuse.org/tests/3800617
    - https://openqa.opensuse.org/tests/3800618
    - https://openqa.opensuse.org/tests/3800619
    - https://openqa.opensuse.org/tests/3800760