### PR TITLE
Add a separate test to schedule all Python tests in a single suite

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -341,6 +341,7 @@ scenarios:
       - autoyast_y2_firstboot:
           settings:
             AUTOYAST: autoyast_opensuse/autoyast_firstboot_leap.xml
+      - stack_tests_python
     opensuse-Leap-15.6-NET-x86_64:
       - textmode:
           machine: 64bit
@@ -664,6 +665,7 @@ scenarios:
       - yast2_nfs_v4_server
       - yast2_firstboot
       - security_tpm2
+      - stack_tests_python
     opensuse-Leap-15.6-NET-aarch64:
       - textmode:
           machine: aarch64
@@ -722,6 +724,7 @@ scenarios:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
       - extra_tests_dracut
+      - stack_tests_python
     opensuse-Leap-15.6-NET-ppc64le:
       - minimalx:
           machine: ppc64le

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -165,9 +165,9 @@ scenarios:
       - gnome:
           machine: 64bit
           priority: 45
-#      - gnome:
-#          machine: 64bit_cirrus
-#          priority: 45
+      # - gnome:
+      #   machine: 64bit_cirrus
+      #   priority: 45
       - minimalx:
           machine: 64bit
           priority: 45
@@ -876,10 +876,11 @@ scenarios:
             DESKTOP: textmode
             AUTOYAST: 'autoyast_opensuse/create_hdd/create_hdd_textmode_x86_64_uefi.xml'
       - sys-param-check
-#      - virt-guest-installation-kvm:
-#          machine: 64bit-ipmi
-#      - virt-guest-installation-xen:
-#          machine: 64bit-ipmi
+      - stack_tests_python
+      #  - virt-guest-installation-kvm:
+      #   machine: 64bit-ipmi
+      # - virt-guest-installation-xen:
+      #   machine: 64bit-ipmi
     opensuse-Tumbleweed-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi


### PR DESCRIPTION
Scheduled in Tumbleweed and LEAP by moving all common Python-related functionality to a separate test. 
Progress ticket : https://progress.opensuse.org/issues/138401
