### PR TITLE
Drop vagrant tests on aarch64

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -567,10 +567,6 @@ scenarios:
           machine: RPi4
           settings:
             PASSWORD: linux
-      - jeos_extra_tests_vagrant:
-          machine: RPi4
-          settings:
-            PASSWORD: linux
     opensuse-Tumbleweed-KDE-Live-aarch64:
       - kde-live:
           machine: USBboot_aarch64-3G


### PR DESCRIPTION
This is required as a consequence of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18244