### PR TITLE
Tumbleweed: aarch64: Enable jeos-ltp-cve

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -567,6 +567,10 @@ scenarios:
           machine: RPi4
           settings:
             PASSWORD: linux
+      - jeos-ltp-cve:
+          machine: RPi4
+          settings:
+            PASSWORD: linux
     opensuse-Tumbleweed-KDE-Live-aarch64:
       - kde-live:
           machine: USBboot_aarch64-3G


### PR DESCRIPTION
verification run: https://openqa.opensuse.org/tests/3854631

NOTE: once we analyse problem on epoll_pwait03 LTP test, also jeos-ltp-syscalls@RPi4 will be moved to this group
 

https://openqa.opensuse.org/tests/3854632#step/epoll_pwait03/6