### PR TITLE
Move Leap 15.4/15.5 incidents installation tests to use autoyast

### DIFF
--- a/job_groups/opensuse_leap_15.4_incidents.yaml
+++ b/job_groups/opensuse_leap_15.4_incidents.yaml
@@ -21,7 +21,13 @@ products:
 scenarios:
   x86_64:
     opensuse-15.4-DVD-Incidents-x86_64:
-      - kde
-      - gnome
+      - kde:
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml
+      - gnome:
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml
       - cryptlvm:
           machine: uefi-2G
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml

--- a/job_groups/opensuse_leap_15.5_incidents.yaml
+++ b/job_groups/opensuse_leap_15.5_incidents.yaml
@@ -21,7 +21,13 @@ products:
 scenarios:
   x86_64:
     opensuse-15.5-DVD-Incidents-x86_64:
-      - kde
-      - gnome
+      - kde:
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml
+      - gnome:
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml
       - cryptlvm:
           machine: uefi-2G
+          settings:
+            YAML_SCHEDULE: schedule/functional/leap15_incidents/incident_update.yaml


### PR DESCRIPTION
https://progress.opensuse.org/issues/153166

VR: 
[leap 15.5 incidents](https://openqa.opensuse.org/tests/overview?arch=&flavor=&machine=&test=&modules=prepare_profile&module_re=&group_glob=&not_group_glob=&distri=opensuse&build=rfan0108&version=15.5#)
[leap 15.4 incidents](https://openqa.opensuse.org/tests/overview?distri=opensuse&build=rfan0109&version=15.4)

Code changes can be found at https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18406
**Please ignore the failed test modules, they are known issues**