### PR TITLE
Update deprecated set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           git diff --diff-filter="ACMRTUXD" omaster job_groups/
           CHANGED_FILES=$(git diff --diff-filter="ACMRTUX" --name-only origin/master job_groups/ | tr '\n' ' ')
           echo $CHANGED_FILES
-          echo "::set-output name=files::${CHANGED_FILES}"
+          echo "files=${CHANGED_FILES}" >> $GITHUB_OUTPUT
 
       - name: Run yamllint for modified job group schedules
         run: |


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The testsuite on this PR won't reflect the changes as this repo uses `pull_request_target`.