### PR TITLE
Install k3s with coredns

### DIFF
--- a/job_groups/opensuse_leap_15.4_updates.yaml
+++ b/job_groups/opensuse_leap_15.4_updates.yaml
@@ -161,6 +161,7 @@ scenarios:
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
             K3S_SYMLINK: 'skip'
             K8S_CLIENT: 'kubernetes1.24-client'
+            K3S_ENABLE_COREDNS: '1'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_leap_15.5_updates.yaml
+++ b/job_groups/opensuse_leap_15.5_updates.yaml
@@ -142,6 +142,7 @@ scenarios:
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
             K3S_SYMLINK: 'skip'
             K8S_CLIENT: 'kubernetes1.24-client'
+            K3S_ENABLE_COREDNS: '1'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -313,6 +313,7 @@ scenarios:
           settings:
             CONTAINER_RUNTIMES: 'kubectl'
             K3S_INSTALL_UPSTREAM: '1'
+            K3S_ENABLE_COREDNS: '1'
       - containers_hpc_apptainer:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -240,6 +240,7 @@ scenarios:
           settings:
             CONTAINER_RUNTIMES: 'kubectl'
             K3S_INSTALL_UPSTREAM: '1'
+            K3S_ENABLE_COREDNS: '1'
       - containers_host_podman:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Most of the k3s usage is utterly basic in our tests. In order to reduce
k3s installation issues, some services have been limited by
default and should be required explicitly.