### PR TITLE
kernel: Remove ltp_connectors

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -71,7 +71,6 @@ scenarios:
       - ltp_can
       - ltp_capbounds
       - ltp_commands
-      - ltp_connectors
       - ltp_containers
       - ltp_controllers
       - ltp_cpuhotplug
@@ -216,7 +215,6 @@ scenarios:
       - ltp_can
       - ltp_capbounds
       - ltp_commands
-      - ltp_connectors
       - ltp_containers
       - ltp_controllers
       - ltp_cpuhotplug
@@ -354,7 +352,6 @@ scenarios:
       - ltp_can
       - ltp_capbounds
       - ltp_commands
-      - ltp_connectors
       - ltp_containers
       - ltp_controllers
       - ltp_cpuhotplug


### PR DESCRIPTION
The runtest has been removed from LTP:

https://github.com/linux-test-project/ltp/commit/9b642d89c