### PR TITLE
Enable basic wicked tests in Tumbleweed PowerPC job group

### DIFF
--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -84,6 +84,8 @@ scenarios:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/ext4/ext4_textmode.yaml
       - extra_tests_dracut
+      - wicked_basic_sut
+      - wicked_basic_ref
     opensuse-Tumbleweed-NET-ppc64le:
       - minimalx:
           machine: ppc64le


### PR DESCRIPTION
This scenario generally works now since I have setup the tap worker class on our PowerPC worker, see
https://progress.opensuse.org/issues/137771#note-10 and subsequent comments. This test scenarios is already scheduled in the regular x86_64 Tumbleweed job group.