### PR TITLE
opensuse_tumbleweed_aarch64.yaml: Test microos-wizard with and without TPM

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -140,7 +140,18 @@ scenarios:
       - microos_fips
     microos-*-MicroOS-Image-sdboot-aarch64:
       - microos-combustion
-      - microos-wizard
+      - microos-wizard-tpm:
+          testsuite: microos-wizard
+          settings:
+            # jeos-firstboot sets up FDE by default
+            ENCRYPT: '1'
+            # Test with TPM enrollment
+            QEMUTPM: 'instance'
+      - microos-wizard:
+          settings:
+            # jeos-firstboot sets up FDE by default
+            ENCRYPT: '1'
+            # Test without TPM enrollment
     opensuse-Tumbleweed-DVD-aarch64:
       - security_tpm2
       - unlock_luks2_volume_with_tpm2:


### PR DESCRIPTION
Same as x86_64.

VRs:
https://openqa.opensuse.org/tests/3887507#live
https://openqa.opensuse.org/tests/3887506#live