### PR TITLE
podman: Skip upstream tests according to scenario

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -298,7 +298,11 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
-            PODMAN_BATS_SKIP: '120-load 125-import 250-systemd 255-auto-update 520-checkpoint'
+            PODMAN_BATS_SKIP: '125-import'
+            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 250-systemd 255-auto-update 520-checkpoint'
+            PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'
+            PODMAN_BATS_SKIP_USER_LOCAL: '250-systemd 255-auto-update'
+            PODMAN_BATS_SKIP_USER_REMOTE: 'none'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -261,7 +261,11 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
-            PODMAN_BATS_SKIP: '120-load 125-import 250-systemd 255-auto-update 520-checkpoint'
+            PODMAN_BATS_SKIP: '125-import'
+            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 250-systemd 255-auto-update 520-checkpoint'
+            PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'
+            PODMAN_BATS_SKIP_USER_LOCAL: '250-systemd 255-auto-update'
+            PODMAN_BATS_SKIP_USER_REMOTE: 'none'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Skip upstream tests according to scenario

Verification run: https://openqa.opensuse.org/tests/3909938

Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18556