### PR TITLE
Update PostGREST host

### DIFF
--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -173,9 +173,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - container_image_on_leap15.2_host:
           testsuite: container-image
           description: 'Container image validation on Leap 15.2 GM'
@@ -262,6 +261,5 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.3/images/totest/containers/opensuse/leap:15.3'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -200,9 +200,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - container_image_on_leap15.2_host:
           testsuite: container-image
           description: 'Container image validation on Leap 15.2 GM'
@@ -348,9 +347,8 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.4/images/totest/containers/opensuse/leap:15.4'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
     opensuse-Leap-15.4-CR-DVD-aarch64:
       - textmode:
           machine: aarch64

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -185,9 +185,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - container_image_on_leap15.2_host:
           testsuite: container-image
           description: 'Container image validation on Leap 15.2 GM'
@@ -285,6 +284,5 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.5/images/totest/containers/opensuse/leap:15.5'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'

--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -185,9 +185,8 @@ scenarios:
           settings:
             HDD_1: 'opensuse-15.3-x86_64-20210906-4-textmode@64bit.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - container_image_on_leap15.2_host:
           testsuite: container-image
           description: 'Container image validation on Leap 15.2 GM'
@@ -285,6 +284,5 @@ scenarios:
             HDD_1: 'opensuse-15.3-aarch64-160.3-textmode@aarch64.qcow2'
             UEFI_PFLASH_VARS: 'opensuse-15.3-aarch64-160.3-textmode@aarch64-uefi-vars.qcow2'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -329,9 +329,8 @@ scenarios:
             K3S_INSTALL_UPSTREAM: '1'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - extra_tests_ai_ml
       - yast_no_self_update
       - gnome-gdm:
@@ -884,8 +883,8 @@ scenarios:
           machine: 64bit_virtio
           priority: 48
           settings:
-            POSTGRES_IP: '10.137.0.6'
-            POSTGRES_PORT: '8080'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - jeos-combustion:
           machine: 64bit_virtio
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -281,9 +281,8 @@ scenarios:
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
-            # Temporarily disabled due to db instance being down
-            IMAGE_STORE_DATA: '0'
-            POSTGRES_IP: '18.196.183.86'
+            POSTGRES_IP: 'ko.dmz-prg2.suse.org'
+            POSTGRES_PORT: '5444'
       - create_hdd_textmode_secureboot:
           testsuite: null
           machine: aarch64-secureboot-opensuse-key


### PR DESCRIPTION
Update the PostGREST host for collection image stats to the new ko host.

* Related ticket: https://progress.opensuse.org/issues/138371
* Related to: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18651