### PR TITLE
Don't need to define 'K8S_CLIENT' for leap15.6

### DIFF
--- a/job_groups/opensuse_leap_15.6_updates.yaml
+++ b/job_groups/opensuse_leap_15.6_updates.yaml
@@ -141,7 +141,7 @@ scenarios:
             START_AFTER_TEST: 'create_hdd_leap_textmode_autoyast'
             HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%_ay@%MACHINE%.qcow2'
             K3S_SYMLINK: 'skip'
-            K8S_CLIENT: 'kubernetes1.24-client'
+            K8S_CLIENT: ''
             K3S_ENABLE_COREDNS: '1'
       - extra_tests_textmode_docker_containers:
           testsuite: extra_tests_textmode_containers


### PR DESCRIPTION
https://progress.opensuse.org/issues/157150

VR: https://openqa.opensuse.org/tests/4015120#