### PR TITLE
NFS: Supportserver for intel is not using arch in the name

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -439,7 +439,7 @@ scenarios:
             VIDEOMODE: text
             DESKTOP: "textmode"
             WORKER_CLASS: tap
-            HDD_1: "support_server_tumbleweed@%ARCH%.qcow2"
+            HDD_1: "support_server_tumbleweed@64bit.qcow2"
             START_AFTER_TEST: create_hdd_textmode
             YAML_SCHEDULE: schedule/storage/supportserver.yaml
             MULTIMACHINE_NODES: "2"


### PR DESCRIPTION
[NFS: Supportserver for intel is not using arch in the name](https://github.com/os-autoinst/opensuse-jobgroups/pull/435/commits/04b29f643f191e10534d9c0b7bf38820f85f941d)

We see in the logs:
Found HDD_1, caching support_server_tumbleweed@x86_64.qcow2
Downloading support_server_tumbleweed@x86_64.qcow2, request #209615 sent to Cache Service
...
Download of "/var/lib/openqa/cache/openqa.opensuse.org/support_server_tumbleweed@x86_64.qcow2" failed: 404 Not Found

Earlier change was using %ARCH% which is correct for ARM but isn't for
intel so this patch is moving back from:
HDD_1: "support_server_tumbleweed@%ARCH%.qcow2"
to:
HDD_1: "support_server_tumbleweed@64bit.qcow2"