### PR TITLE
Change Windows images to use 22H2

### DIFF
--- a/job_groups/opensuse_leap_15.2_wsl.yaml
+++ b/job_groups/opensuse_leap_15.2_wsl.yaml
@@ -29,7 +29,7 @@ scenarios:
             QEMUMACHINE: 'q35'
             SCC_REGISTER: '0'
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
-            HDD_1: 'windows-10-x86_64-21H1@64bit_win.qcow2'
+            HDD_1: 'windows-10-x86_64-22H2@windows_bios_boot.qcow2'
             VNC_STALL_THRESHOLD: '10'
             VNC_TYPING_LIMIT: '15'
             QEMU_ENABLE_SMBD: '1'
@@ -38,7 +38,7 @@ scenarios:
           machine: uefi_win
           settings:
             <<: *settings
-            HDD_1: 'windows-10-x86_64-21H1@uefi_win.qcow2'
+            HDD_1: 'windows-10-x86_64-22H2@windows_uefi_boot.qcow2'
       - wsl2-main:
           testsuite: null
           settings:

--- a/job_groups/opensuse_leap_15.4_wsl.yaml
+++ b/job_groups/opensuse_leap_15.4_wsl.yaml
@@ -29,7 +29,7 @@ scenarios:
             QEMUMACHINE: 'q35'
             SCC_REGISTER: '0'
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
-            HDD_1: 'windows-10-x86_64-21H2@64bit_win.qcow2'
+            HDD_1: 'windows-10-x86_64-22H2@windows_bios_boot.qcow2'
             WIN_VERSION: '10'
             VNC_STALL_THRESHOLD: '10'
             VNC_TYPING_LIMIT: '15'
@@ -40,7 +40,7 @@ scenarios:
           machine: uefi_win
           settings:
             <<: *settings
-            HDD_1: 'windows-10-x86_64-21H2@uefi_win.qcow2'
+            HDD_1: 'windows-10-x86_64-22H2@windows_uefi_boot.qcow2'
       - wsl2-main:
           testsuite: null
           settings:

--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -239,7 +239,7 @@ scenarios:
             DESKTOP: gnome
             DUALBOOT: '1'
             HDDVERSION: Windows 10
-            HDD_1: windows-10-x86_64-1903@%MACHINE%.qcow2
+            HDD_1: windows-10-x86_64-22H2@windows_bios_boot.qcow2
             VNC_STALL_THRESHOLD: '100'
             EXCLUDE_MODULES: system_prepare
           description: ''

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -630,7 +630,7 @@ scenarios:
       - desktopapps-remote-desktop-xrdp-server1:
           settings:
             BOOTFROM: c
-            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-22H2@windows_bios_boot.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
@@ -661,7 +661,7 @@ scenarios:
       - desktopapps-remote-desktop-xrdp-server2:
           settings:
             BOOTFROM: c
-            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-22H2@windows_bios_boot.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap
@@ -682,7 +682,7 @@ scenarios:
           settings:
             BOOTFROM: c
             DESKTOP: gnome
-            HDD_1: windows-10-x86_64-21H2@64bit_win.qcow2
+            HDD_1: windows-10-x86_64-22H2@windows_bios_boot.qcow2
             WIN_VERSION: '10'
             NETWORKS: fixed
             NICTYPE: tap


### PR DESCRIPTION
Some Windows images were very old, using 21H1 or even 1903 versions. After making some cleanup in O3, there's need to update the yaml files of those jobs to use 22H2