### PR TITLE
kernel: s390x: Add 5 LTP tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -287,9 +287,15 @@ scenarios:
       - xfstests_nfs3-nfs
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
+      - ltp_controllers
       - ltp_cve
       - ltp_crypto_pty_commands
+      - ltp_kernel_misc
+      - ltp_lvm
+      - ltp_net_features
       - ltp_net_nfs
+      - ltp_net_stress_ipsec_icmp
+      - ltp_net_stress_ipsec_tcp
       - ltp_syscalls
       - kernel-live-patching:
           settings:


### PR DESCRIPTION
Add more common LTP tests to cover at least some features:
- ltp_controllers
- ltp_kernel_misc
- ltp_lvm
- ltp_net_features
- ltp_net_stress_ipsec_icmp
- ltp_net_stress_ipsec_tcp

We probably don't have enough resources to run whole LTP coverage (and z/VM requires installing Tumbleweed first as it does not support reusing qcow images, thus it's slow), therefore cover just small part of whole LTP testing.