### PR TITLE
opensuse_leap_15: drop transactional_server test

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -245,9 +245,6 @@ scenarios:
           description: ''
           testsuite: null
           machine: uefi_win
-      - transactional_server:
-          settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/transactional_server/transactional_server.yaml
       - install_offline
       - system_performance:
           machine: 64bit-2G
@@ -534,9 +531,6 @@ scenarios:
             YAML_SCHEDULE: schedule/virtualization/virtualization.yaml
       - toolchain_zypper
       - systemd-networkd
-      - transactional_server:
-          settings:
-            YAML_SCHEDULE: schedule/yast/opensuse/transactional_server/transactional_server.yaml
       - install_offline
       - system_performance
       - lvm-encrypt-separate-boot:


### PR DESCRIPTION
transactional-server role got dropped from skelcd-control in Leap 15.6


Related ticket: https://progress.opensuse.org/issues/158577

And please also see https://build.opensuse.org/request/show/1161383 and https://bugzilla.opensuse.org/show_bug.cgi?id=1221742