### PR TITLE
Set QEMUCPUS=2 for podman_testsuite

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -307,6 +307,7 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
+            QEMUCPUS: '2'
             PODMAN_BATS_SKIP: '125-import'
             PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 250-systemd 255-auto-update 520-checkpoint'
             PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -268,6 +268,7 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
+            QEMUCPUS: '2'
             PODMAN_BATS_SKIP: '125-import'
             PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 250-systemd 255-auto-update 520-checkpoint'
             PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'


### PR DESCRIPTION
Set QEMUCPUS=2 for podman_testsuite.

The new runc test needs QEMUCPUS=2 to test cpu control functionality.

https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19226