### PR TITLE
Leap 15.x Images: For kde-live-wayland, set QEMUCPUS=2

### DIFF
--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -131,6 +131,9 @@ scenarios:
       - kde-live_installation
       - kde-live-wayland:
           machine: 64bit_virtio-3G
+          settings:
+            # Mitigate boo#1189174
+            QEMUCPUS: "2"
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
           machine: 64bit

--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -135,6 +135,9 @@ scenarios:
       - kde-live_installation
       - kde-live-wayland:
           machine: 64bit_virtio-3G
+          settings:
+            # Mitigate boo#1189174
+            QEMUCPUS: "2"
       - kde_live_upgrade_leap_42.3
       - kde_live_upgrade_leap_15.0:
           machine: 64bit


### PR DESCRIPTION
The additional core helps with a very busy firefox.

Before: https://openqa.opensuse.org/tests/4175358#next_previous (all red)
VRs: https://openqa.opensuse.org/tests/4183115 https://openqa.opensuse.org/tests/4183116 https://openqa.opensuse.org/tests/4183117 https://openqa.opensuse.org/tests/4183118 (all green)