### PR TITLE
Add netavark skip variables to TW

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -320,6 +320,7 @@ scenarios:
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_USER: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'
+            NETAVARK_BATS_SKIP: "001-basic 100-bridge-iptables 200-bridge-firewalld 250-bridge-nftables 500-plugin"
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -280,6 +280,7 @@ scenarios:
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_USER: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'
+            NETAVARK_BATS_SKIP: "001-basic 100-bridge-iptables 200-bridge-firewalld 250-bridge-nftables 500-plugin"
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19288

Related ticket: https://progress.opensuse.org/issues/160254
Verification runs: 
  - opensuse-Tumbleweed-DVD-x86_64-Build20240511-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/t4183773