### PR TITLE
Fix buildah skip variables

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -328,8 +328,8 @@ scenarios:
           settings:
             CONTAINER_RUNTIMES: 'podman'
             BUILDAH_BATS_SKIP: "commit copy run"
-            BUILDAH_BATS_SKIP_USER: 'none'
-            BUILDAH_BATS_SKIP_ROOT: "add basic bud chroot overlay rmi sbom squash"
+            BUILDAH_BATS_SKIP_ROOT: 'none'
+            BUILDAH_BATS_SKIP_USER: "add basic bud chroot overlay rmi sbom squash"
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Fix previous https://github.com/os-autoinst/opensuse-jobgroups/pull/456

I got the root & user variables switched.

Same VR as before: https://openqa.opensuse.org/tests/4188708