### PR TITLE
opensuse_tumbleweed.yaml: Use LUKS2 TEST_DATA for more LVM encryption tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -208,6 +208,7 @@ scenarios:
           machine: uefi
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+            YAML_TEST_DATA: test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
       - cryptlvm:
           machine: 64bit
           settings:
@@ -1066,6 +1067,8 @@ scenarios:
             REGISTRY: '3.71.98.16:5000'
       - cryptlvm:
           machine: 64bit
+          settings:
+            YAML_TEST_DATA: test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
       - install_only:
           machine: smp_64
           priority: 40


### PR DESCRIPTION
https://progress.opensuse.org/issues/160841

crypt_no_lvm not yet addressed - that needs some more changes