### PR TITLE
Add bud & sbom tests to BUILDAH_BATS_SKIP

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -328,9 +328,9 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
-            BUILDAH_BATS_SKIP: "commit copy run"
+            BUILDAH_BATS_SKIP: "commit copy bud run sbom"
             BUILDAH_BATS_SKIP_ROOT: 'none'
-            BUILDAH_BATS_SKIP_USER: "add basic bud chroot overlay rmi sbom squash"
+            BUILDAH_BATS_SKIP_USER: "add basic chroot overlay rmi squash"
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
These subtests pulls too much images resulting in `no space left on device): exit status 1`.  They were already ignored as rootless for the same reason.  Do the same for root.

Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1225288