### PR TITLE
Fix luks issue

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -232,7 +232,9 @@ scenarios:
             YAML_SCHEDULE: schedule/virtualization/virtualization.yaml
             QEMU_VIRTIO_RNG: "0"
       - toolchain_zypper
-      - crypt_no_lvm
+      - crypt_no_lvm:
+          settings:
+            +YAML_TEST_DATA: ''
       - gnome_dual_windows10:
           settings:
             CDMODEL: ide-cd

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -213,6 +213,7 @@ scenarios:
           machine: 64bit
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+            YAML_TEST_DATA: test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
       - install_only:
           machine: smp_64
           priority: 40

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -653,6 +653,7 @@ scenarios:
       - cryptlvm:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/encryption/cryptlvm.yaml
+            YAML_TEST_DATA: test_data/yast/encryption/lvm_encrypt_separate_boot_luks2.yaml
             GRUB_KERNEL_OPTION_APPEND: ''
       - install_only:
           machine: aarch64


### PR DESCRIPTION
cryptlvm on TW should be luks2, crypt_no_lvm on leap should be luks1.

Related ticket: https://progress.opensuse.org/issues/160841

VR:
https://openqa.opensuse.org/tests/4227770#  cryptlvm on TW
https://openqa.opensuse.org/tests/4227255#  crypt_no_lvm on leap