### PR TITLE
15.6 Images: Remove QEMU_VIRTIO_RNG=0 for 15.2 and 15.3

### DIFF
--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -146,12 +146,10 @@ scenarios:
           machine: uefi
           settings:
             QEMURAM: "2048"
-            QEMU_VIRTIO_RNG: "0"
       - kde_live_upgrade_leap_15.3:
           machine: 64bit
           settings:
             QEMURAM: "2048"
-            QEMU_VIRTIO_RNG: "0"
     opensuse-Leap15.6-Rescue-CD-x86_64:
       - rescue
       - rescue:


### PR DESCRIPTION
The 15.2@uefi image needs QEMU_VIRTIO_RNG to find the resume device. 15.3+ uses by-uuid and doesn't care.

VRs:
* 15.2: https://openqa.opensuse.org/tests/4231104
* 15.3: https://openqa.opensuse.org/tests/4231282