### PR TITLE
opensuse_leap_15: add zdup-Leap-15.5-gnome and zdup-Leap-15.5-kde

### DIFF
--- a/job_groups/opensuse_leap_15.yaml
+++ b/job_groups/opensuse_leap_15.yaml
@@ -224,6 +224,8 @@ scenarios:
             QEMU_VIRTIO_RNG: "0"
       - zdup-Leap-15.4-gnome
       - zdup-Leap-15.4-kde_to_Leap
+      - zdup-Leap-15.5-gnome
+      - zdup-Leap-15.5-kde
       - yast2_ncurses:
           settings:
             YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses_leap.yaml
@@ -414,6 +416,8 @@ scenarios:
             QEMU_VIRTIO_RNG: "0"
       - zdup-Leap-15.4-gnome
       - zdup-Leap-15.4-kde_to_Leap
+      - zdup-Leap-15.5-gnome
+      - zdup-Leap-15.5-kde
   aarch64:
     opensuse-Leap-15.6-DVD-aarch64:
       - textmode:


### PR DESCRIPTION
zdup-Leap-15.5-gnome and zdup-Leap-15.5-kde are tested in [15.6 Updates group](https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.6&build=20240530-1&groupid=122), we should also test them in 15 GA testgroup.