### PR TITLE
containers: No need to skip buildah tests as root

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -345,9 +345,9 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
-            BUILDAH_BATS_SKIP: "commit copy bud run sbom"
+            BUILDAH_BATS_SKIP: 'commit run'
             BUILDAH_BATS_SKIP_ROOT: 'none'
-            BUILDAH_BATS_SKIP_USER: "add basic chroot overlay rmi squash"
+            BUILDAH_BATS_SKIP_USER: 'add basic bud copy overlay rmi sbom squash'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -291,8 +291,6 @@ scenarios:
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_USER: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'
-            NETAVARK_BATS_SKIP: "001-basic 100-bridge-iptables 200-bridge-firewalld 250-bridge-nftables 500-plugin"
-            AARDVARK_BATS_SKIP: "100-basic-name-resolution 200-two-networks 300-three-networks 500-reverse-lookups"
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
We no longer need to skip as root some tests that were buggy due to space issues.

Verification run:
- https://openqa.opensuse.org/tests/4275638 (see `BATS:` record_info suggestions).