### PR TITLE
No need to skip any upstream aardvark-dns tests anymore

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -342,7 +342,7 @@ scenarios:
             SKOPEO_BATS_SKIP_USER: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'
             NETAVARK_BATS_SKIP: "001-basic 100-bridge-iptables 200-bridge-firewalld 250-bridge-nftables 500-plugin"
-            AARDVARK_BATS_SKIP: "100-basic-name-resolution 200-two-networks 300-three-networks 500-reverse-lookups"
+            AARDVARK_BATS_SKIP: 'none'
       - containers_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-


### PR DESCRIPTION
As a result of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19541 we don't need to skip aardvark-dns upstream tests anymore.

Verification runs (the same for the above PR):
- opensuse-Tumbleweed-DVD-x86_64-Build20240617-containers_host_podman_testsuite@64bit -> https://openqa.opensuse.org/tests/4278634
- opensuse-Tumbleweed-DVD-aarch64-Build20240611-containers_host_podman_testsuite@aarch64 -> https://openqa.opensuse.org/tests/4278635