### PR TITLE
Use CentOS Stream 9 image

### DIFF
--- a/job_groups/opensuse_leap_15.2_images.yaml
+++ b/job_groups/opensuse_leap_15.2_images.yaml
@@ -100,7 +100,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
       - container_image_on_ubuntu_host:
           testsuite: container-image

--- a/job_groups/opensuse_leap_15.3_images.yaml
+++ b/job_groups/opensuse_leap_15.3_images.yaml
@@ -152,7 +152,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_leap_15.4_images.yaml
+++ b/job_groups/opensuse_leap_15.4_images.yaml
@@ -179,7 +179,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -167,7 +167,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -167,7 +167,7 @@ scenarios:
           testsuite: container-image
           description: 'Container image validation on CentOS 8.2'
           settings:
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             KEEP_GRUB_TIMEOUT: '1'
             DESKTOP: 'textmode'
             VIDEOMODE: 'text'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1139,7 +1139,7 @@ scenarios:
             VIDEOMODE: text
             KEEP_GRUB_TIMEOUT: '1'
             BOOT_HDD_IMAGE: '1'
-            HDD_1: 'centOS-Stream-8-x86_64-20230213-minimal.qcow2'
+            HDD_1: 'centos-stream9.qcow2'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed'
             CONTAINERS_NO_SUSE_OS: "1"


### PR DESCRIPTION
Use CentOS Stream 9 image.

Related ticket: https://progress.opensuse.org/issues/161738
Verification run: https://openqa.opensuse.org/tests/4312875

NOTE: `centos-stream9_template.qcow2` was renamed to `centos-stream9.qcow2` after VR.