### PR TITLE
kernel: Add KOTD jobs

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -57,6 +57,11 @@ products:
 scenarios:
   aarch64:
     opensuse-Tumbleweed-DVD-aarch64:
+      - install_ltp_kotd+opensuse+DVD:
+          settings:
+            KOTD_REPO: 'https://download.opensuse.org/repositories/Kernel:/HEAD/ARM/'
+      - ltp_cve_kotd
+      - ltp_syscalls_kotd
       - extra_tests_kernel
       - bpftools
       - io_uring
@@ -197,6 +202,11 @@ scenarios:
       - ltp_syscalls
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
+      - install_ltp_kotd+opensuse+DVD:
+          settings:
+            KOTD_REPO: 'https://download.opensuse.org/repositories/Kernel:/HEAD/PPC/'
+      - ltp_cve_kotd
+      - ltp_syscalls_kotd
       - extra_tests_kernel
       - bpftools
       - io_uring
@@ -296,6 +306,9 @@ scenarios:
             INSTALL_LTP: ''
   x86_64:
     opensuse-Tumbleweed-DVD-x86_64:
+      - install_ltp_kotd+opensuse+DVD
+      - ltp_cve_kotd
+      - ltp_syscalls_kotd
       - extra_tests_kernel
       - bpftools
       - io_uring


### PR DESCRIPTION
Temporarily add KOTD (install_ltp, ltp_cve and ltp_syscalls) to kernel builds.

Later we schedule separate daily builds in kernel group.

Verification run:
- https://openqa.opensuse.org/tests/4325848
- https://openqa.opensuse.org/tests/4325989
- https://openqa.opensuse.org/tests/4325990