### PR TITLE
job_groups/opensuse_leap_15.6_images.yaml: More RAM for KDE-Live on Arm

### DIFF
--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -249,8 +249,12 @@ scenarios:
       - kde-live_installation
       - kde_live_upgrade_leap_15.0:
           machine: aarch64
+          settings:
+            QEMURAM: "3072"
       - kde_live_upgrade_leap_15.3:
           machine: aarch64
+          settings:
+            QEMURAM: "3072"
       - mediacheck
     opensuse-Leap15.6-GNOME-Live-aarch64:
       - gnome-live


### PR DESCRIPTION
Like x86_64, make the tests significantly more reliable.