### PR TITLE
Set NCAT_VERSION for netavark upstream tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -343,6 +343,7 @@ scenarios:
             SKOPEO_BATS_SKIP_ROOT: 'none'
             NETAVARK_BATS_SKIP: "001-basic 100-bridge-iptables 200-bridge-firewalld 250-bridge-nftables 500-plugin"
             AARDVARK_BATS_SKIP: 'none'
+            NCAT_VERSION: '7.95-2'
       - containers_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-


### PR DESCRIPTION
This PR:
- Sets NCAT_VERSION for netavark upstream tests
- Drops `200-bridge-firewalld` from `NETAVARK_BATS_SKIP`

```
$ podman run --rm ghcr.io/ricardobranco777/susebats notok  https://openqa.opensuse.org/tests/4348644 | grep NETAVARK
NETAVARK_BATS_SKIP='001-basic 100-bridge-iptables 250-bridge-nftables 500-plugin'
```

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19774
- Verification run: https://openqa.opensuse.org/tests/4348689