### PR TITLE
microos-sdboot: use uefi_virtio-2G

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -98,7 +98,7 @@ scenarios:
       - microos:
           machine: uefi
       - microos-sdboot:
-          machine: uefi
+          machine: uefi_virtio-2G
       - microos:
           machine: 64bit
       - microos_textmode


### PR DESCRIPTION
The installer needs more memory