### PR TITLE
microos-sdboot: uefi-2G instead of uefi_virtio-2G

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -98,7 +98,7 @@ scenarios:
       - microos:
           machine: uefi
       - microos-sdboot:
-          machine: uefi_virtio-2G
+          machine: uefi-2G
       - microos:
           machine: 64bit
       - microos_textmode


### PR DESCRIPTION
Fixes 1d2228ad72ca39f0ee96edda8c28d3b1bd26708e