### PR TITLE
Use new gnome-agama group poo#164141

### DIFF
--- a/job_groups/opensuse_leap_16.0_images.yaml
+++ b/job_groups/opensuse_leap_16.0_images.yaml
@@ -22,13 +22,13 @@ products:
 scenarios:
   x86_64:
     opensuse-agama-installer-openSUSE-x86_64:
-      - gnome-live:
+      - gnome-agama:
           machine: uefi-3G
-      - gnome-live:
+      - gnome-agama:
           machine: 64bit-3G
-      - gnome-live:
+      - gnome-agama:
           machine: uefi-usb-4G
-      - gnome-live:
+      - gnome-agama:
           machine: USBboot_64-3G
       - mediacheck:
           machine: 64bit


### PR DESCRIPTION
gnome-agama was created here https://openqa.opensuse.org/admin/test_suites
![image](https://github.com/user-attachments/assets/6f2f11f0-7a91-4c44-8769-9c959b8d648b)

The general idea is have a test suite based on gnome. we want to skip all the legacy installer steps and add agama-welcome and similar.

Progress ticket https://progress.opensuse.org/issues/164141


