### PR TITLE
riscv64: Enable diskusage

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -24,7 +24,7 @@ scenarios:
     opensuse-Tumbleweed-JeOS-for-RISCV-riscv64:
       - jeos:
           settings:
-            EXCLUDE_MODULES: diskusage,libzypp_config
+            EXCLUDE_MODULES: libzypp_config
       - jeos-ltp-commands:
           settings:
             EXCLUDE_MODULES: libzypp_config


### PR DESCRIPTION
diskusage was fixed for riscv64 in
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19899

Suggested-by: Fabian Vogt <fvogt@suse.de>