### PR TITLE
tumbleweed: set QEMU_DISABLE_SNAPSHOTS=1 whenever QEMUTPM=instance is used

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -167,6 +167,7 @@ scenarios:
             ENCRYPT: '1'
             # Test with TPM enrollment
             QEMUTPM: 'instance'
+            QEMU_DISABLE_SNAPSHOTS: '1'
       - microos-wizard:
           machine: uefi
           settings:
@@ -682,6 +683,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUTPM: 'instance'
             QEMUTPM_VER: '2.0'
+            QEMU_DISABLE_SNAPSHOTS: '1'
       - security_tpm_selftest
       - secureboot_kernel_lockdown:
           testsuite: null

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -164,6 +164,7 @@ scenarios:
             ENCRYPT: '1'
             # Test with TPM enrollment
             QEMUTPM: 'instance'
+            QEMU_DISABLE_SNAPSHOTS: '1'
       - microos-wizard:
           settings:
             # jeos-firstboot sets up FDE by default
@@ -182,6 +183,7 @@ scenarios:
             QEMURAM: '4096'
             QEMUTPM: 'instance'
             QEMUTPM_VER: '2.0'
+            QEMU_DISABLE_SNAPSHOTS: '1'
             UEFI_PFLASH_VARS: '/usr/share/qemu/aavmf-aarch64-vars.bin'
             GRUB_KERNEL_OPTION_APPEND: ''
       - textmode:
@@ -353,6 +355,7 @@ scenarios:
             YAML_SCHEDULE: schedule/security/tpm_selftest.yaml
             QEMUTPM: 'instance'
             QEMUTPM_VER: '1.2'
+            QEMU_DISABLE_SNAPSHOTS: '1'
             DESKTOP: textmode
       - ima_measure_critical_data:
           testsuite: null


### PR DESCRIPTION
Rollbacks with TPM enabled do not work with current openQA versions
