### PR TITLE
job_groups/opensuse_tumbleweed_aarch64.yaml: Fix jeos-no-cloud test

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -565,7 +565,7 @@ scenarios:
     opensuse-Tumbleweed-JeOS-for-OpenStack-Cloud-aarch64:
       - jeos-no-cloud:
           testsuite: null
-          machine: 64bit_virtio
+          machine: aarch64
           priority: 48
           settings:
             NO_CLOUD: '1'


### PR DESCRIPTION
It needs to run in an aarch64 VM.

VR: https://openqa.opensuse.org/tests/4414827