### PR TITLE
Set NETAVARK_BATS_SKIP for aarch64

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -289,7 +289,7 @@ scenarios:
             MAX_JOB_TIME: '12000'
             QEMUCPUS: '2'
             AARDVARK_BATS_SKIP: 'none'
-            NETAVARK_BATS_SKIP: 'all'
+            NETAVARK_BATS_SKIP: '001-basic 500-plugin'
             PODMAN_BATS_SKIP: '125-import'
             PODMAN_BATS_SKIP_ROOT_LOCAL: '010-images 030-run 120-load 255-auto-update'
             PODMAN_BATS_SKIP_ROOT_REMOTE: 'none'


### PR DESCRIPTION
Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19995

```
$ susebats notok https://openqa.opensuse.org/tests/4414971
NETAVARK_BATS_SKIP='001-basic 500-plugin'
```