### PR TITLE
Add opensuse_leap_16.0.yaml

### DIFF
--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -79,3 +79,4 @@
 123: opensuse_leap_15.6_backports
 125: opensuse_tumbleweed_riscv64
 126: opensuse_leap_16.0_images
+127: opensuse_leap_16.0

--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -79,4 +79,4 @@
 123: opensuse_leap_15.6_backports
 125: opensuse_tumbleweed_riscv64
 126: opensuse_leap_16.0_images
-127: opensuse_leap_16.0
+129: opensuse_leap_16.0

--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -1,0 +1,33 @@
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#            job_groups/opensuse_leap_16.0.yaml            #
+############################################################
+---
+
+defaults:
+  x86_64:
+    machine: 64bit-2G
+    priority: 55
+products:
+  opensuse-agama-installer-x86_64:
+    distri: opensuse
+    flavor: agama-installer
+    version: '16.0'
+scenarios:
+  x86_64:
+    opensuse-agama-installer-x86_64:
+      - gnome-agama:
+          machine: uefi-3G
+      - gnome-agama:
+          machine: 64bit-3G
+      - gnome-agama:
+          machine: uefi-usb-4G
+      - gnome-agama:
+          machine: USBboot_64-3G
+      - mediacheck:
+          machine: 64bit


### PR DESCRIPTION
* this is where we'll newly build agama-installer so we can test new builds together with all unreleased package changes

* Use 16.0 rather than 16 as we will most likely have same maintenance workflow like LeapMicro 6.X

* Existing opensuse_leap_16.0_images.yaml will be used for other appliances than agama-installer

Relevant Progress ticket: https://progress.opensuse.org/issues/164141
