### PR TITLE
Leap: Set LTP_TAINT_EXPECTED for LTP tests + missing setup on Tumbleweed

### DIFF
--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -94,6 +94,8 @@ scenarios:
           machine: 64bit_virtio-2G
       - jeos-ltp-commands:
           machine: 64bit_virtio
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-containers:
           machine: 64bit_virtio
       - jeos-ltp-cve:
@@ -104,6 +106,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-syscalls:
           machine: 64bit_virtio
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio
     opensuse-Leap15.5-GNOME-Live-x86_64:
@@ -239,8 +243,12 @@ scenarios:
       - jeos-ltp-containers
       - jeos-ltp-cve
       - jeos-ltp-dio
-      - jeos-ltp-syscalls
-      - jeos-ltp-commands
+      - jeos-ltp-syscalls:
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
+      - jeos-ltp-commands:
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc
     opensuse-15.5-JeOS-for-RPi-aarch64:
       - jeos:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1054,6 +1054,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-commands:
           machine: uefi_virtio-2G
+          settings:
+            LTP_TAINT_EXPECTED: '0x13801'
       - jeos-ltp-containers:
           machine: uefi_virtio-2G
       - jeos-ltp-cve:
@@ -1064,6 +1066,8 @@ scenarios:
           machine: uefi_virtio-2G
       - jeos-ltp-syscalls:
           machine: uefi_virtio-2G
+          settings:
+            LTP_TAINT_EXPECTED: '0x13801'
       - jeos-ltp-syscalls-ipc:
           machine: uefi_virtio-2G
     opensuse-Tumbleweed-KDE-Live-x86_64:


### PR DESCRIPTION
Leap: Set LTP_TAINT_EXPECTED for LTP tests

Only Leap 15.5 and 15.6 jobs are active, therefore ignore older Leap.

It's needed for It's needed for LTP runtests: commands, syscalls,
kernel_misc (kernel_misc don't run on Leap).

Leap has SLES kernel, therefore taint flags are different from
Tumbleweed, which has mainline stable kernel (Unsupported module was
loaded 0x80000000 is added).

For all tests on o3 only 0x80003000 is needed:

* Out of tree module was loaded (0x1000, 1 << 12)
* Unsigned module was loaded (0x2000, 1 << 13)
* Unsupported module was loaded (2147483648, 0x80000000, 1 << 31)

but we set: 0x80013801

* Proprietary module was loaded (1, 0x1, 1 << 0)
* Workaround for platform firmware bug (2048, 0x800, 1 << 11)
* Out of tree module was loaded (4096, 0x1000, 1 << 12)
* Unsigned module was loaded (8192, 0x2000, 1 << 13)
* Externally supported module was loaded or auxiliary taint (65536, 0x10000, 1 << 16)
* Unsupported module was loaded (2147483648, 0x80000000, 1 << 31)

The additional modules might be needed in the future for PPC/s390x drivers
(so far it's needed only for SLES, but that may change).

+ Add 2x missing setup on Tumbleweed (fix of previous commit)