### PR TITLE
tumbleweed: Schedule jeos-ssh-enroll-wizard

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1066,6 +1066,15 @@ scenarios:
           machine: uefi_virtio-2G
       - jeos-ltp-syscalls-ipc:
           machine: uefi_virtio-2G
+      - jeos-ssh-enroll-server:
+          settings:
+            +HDD_1: 'support_server_tumbleweed@64bit.qcow2'
+            SSH_ENROLL_PAIR: '1'
+            YAML_SCHEDULE: schedule/jeos/supportserver.yaml
+      - jeos-ssh-enroll-wizard:
+          settings:
+            PARALLEL_WITH: jeos-ssh-enroll-server
+            YAML_SCHEDULE: schedule/jeos/ssh-enroll.yaml
     opensuse-Tumbleweed-KDE-Live-x86_64:
       - kde-live:
           machine: uefi-3G


### PR DESCRIPTION
Add the new multi-machine test that targets the SSH Enrollment feature of the JeOS/MinimalVM/MicroOS first run wizard to the Tumbleweed schedule.

- Related ticket:
https://progress.opensuse.org/issues/160664
- Verification runs:
http://rmarliere-openqa.qe.prg2.suse.org/tests/2282
http://rmarliere-openqa.qe.prg2.suse.org/tests/2283
https://openqa.opensuse.org/tests/4468328
https://openqa.opensuse.org/tests/4468330