### PR TITLE
Add a bulk of BCI language and application images

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -386,6 +386,7 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             POSTGRES_IP: 'ko.dmz-prg2.suse.org'
             POSTGRES_PORT: '5444'
+      ### BCI base images
       - bci_init_podman:
           testsuite: null
           settings:
@@ -422,6 +423,13 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/golang:latest
             BCI_IMAGE_MARKER: golang_stable
             BCI_TEST_ENVS: go
+      - bci_rust_oldstable_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: rust_oldstable
+            BCI_TEST_ENVS: rust
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/rust:oldstable
       - bci_rust_podman:
           testsuite: null
           settings:
@@ -436,14 +444,119 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/ruby:latest
             BCI_IMAGE_MARKER: ruby_3.3
             BCI_TEST_ENVS: ruby
+      - bci_gcc_13_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: gcc_13
+            BCI_TEST_ENVS: gcc
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/gcc:13
+      - bci_gcc_14_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: gcc_14
+            BCI_TEST_ENVS: gcc
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/gcc:14
+      - bci_python_3.10_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: python_3.10
+            BCI_TEST_ENVS: python
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/python:3.10
+      - bci_python_3.11_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: python_3.11
+            BCI_TEST_ENVS: python
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/python:3.11
+      - bci_python_3.12_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: python_3.12
+            BCI_TEST_ENVS: python
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/python:3.12
       ### application containers
-      - bci_postgres_podman:
+      - bci_postgres_14_podman:
           testsuite: null
           settings:
             <<: *bci
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/postgres:14
             BCI_IMAGE_MARKER: postgres
             BCI_TEST_ENVS: postgres
+      - bci_postgres_15_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: postgres_15
+            BCI_TEST_ENVS: postgres
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/postgres:15
+      - bci_postgres_16_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: postgres_16
+            BCI_TEST_ENVS: postgres
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/postgres:16
+      - bci_grafana_10_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: grafana_10
+            BCI_TEST_ENVS: grafana
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/grafana:10
+      - bci_helm_latest_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: helm_latest
+            BCI_TEST_ENVS: helm
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/helm
+      - bci_git_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: git_latest
+            BCI_TEST_ENVS: git
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/git
+      - bci_registry_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: registry
+            BCI_TEST_ENVS: distribution
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/distribution
+      - bci_nginx_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: nginx_latest
+            BCI_TEST_ENVS: nginx
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/nginx
+      - bci_pcp_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: pcp
+            BCI_TEST_ENVS: pcp
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/pcp
+      - bci_tomcat_9_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: tomcat_9
+            BCI_TEST_ENVS: tomcat
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/tomcat:9
+      - bci_tomcat_10_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: tomcat_10
+            BCI_TEST_ENVS: tomcat
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/tomcat:10
       - extra_tests_ai_ml
       - yast_no_self_update
       - gnome-gdm:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -479,7 +479,98 @@ scenarios:
             BCI_IMAGE_MARKER: python_3.12
             BCI_TEST_ENVS: python
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/python:3.12
+      - bci_golang_oldstable_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: golang_oldstable
+            BCI_TEST_ENVS: all,metadata,go
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/golang:oldstable
+      - bci_nodejs_20_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: nodejs_20
+            BCI_TEST_ENVS: all,node,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/nodejs:20
+      - bci_nodejs_22_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: nodejs_22
+            BCI_TEST_ENVS: all,node,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/nodejs:22
+      - bci_openjdk_11_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: openjdk_11
+            BCI_TEST_ENVS: all,openjdk,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/openjdk:11
+      - bci_openjdk_21_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: openjdk_21
+            BCI_TEST_ENVS: all,openjdk,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/openjdk:21
+      - bci_openjdk_22_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: openjdk_22
+            BCI_TEST_ENVS: all,openjdk,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/openjdk:22
       ### application containers
+      - bci_prometheus_2_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: prometheus_2
+            BCI_TEST_ENVS: prometheus,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/prometheus:latest
+      - bci_spack_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: spack
+            BCI_TEST_ENVS: all,spack,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/spack:latest
+      - bci_alertmanager_0.27_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: alertmanager_0.27
+            BCI_TEST_ENVS: all,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/alertmanager:latest
+      - bci_mariadb-client_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: mariadb-client_11.4
+            BCI_TEST_ENVS: all,mariadb,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/mariadb-client:latest
+      - bci_389-ds_3.1_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: 389-ds_3.1
+            BCI_TEST_ENVS: all,389ds,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/389-ds:3.1
+      - bci_blackbox_exporter_0.24_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: blackbox_exporter_0.24
+            BCI_TEST_ENVS: all,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/blackbox_exporter:latest
+      - bci_kiwi_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: kiwi_10.1
+            BCI_TEST_ENVS: all,kiwi,metadata
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/kiwi:latest
       - bci_postgres_14_podman:
           testsuite: null
           settings:


### PR DESCRIPTION
Move several language and application images that are verified in dev group into the main TW.

- ticket: https://progress.opensuse.org/issues/164192