### PR TITLE
kernel: Set LTP_TAINT_EXPECTED for various memory tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -206,7 +206,9 @@ scenarios:
       - ltp_ipc
       - ltp_net_ipv6_lib
       - ltp_math
-      - ltp_mm
+      - ltp_mm:
+          settings:
+            LTP_TAINT_EXPECTED: '0x200'
       - ltp_net_tcp_cmds
       - ltp_openposix:
           priority: 50
@@ -383,8 +385,12 @@ scenarios:
             LTP_TAINT_EXPECTED: '0x13801'
       - ltp_lvm
       - ltp_math
-      - ltp_mm
-      - ltp_mm_oom
+      - ltp_mm:
+          settings:
+            LTP_TAINT_EXPECTED: '0x200'
+      - ltp_mm_oom:
+          settings:
+            LTP_TAINT_EXPECTED: '0x200'
       - ltp_mm_swapping
       - ltp_net_features
       - ltp_net_ipv6
@@ -405,7 +411,9 @@ scenarios:
       - ltp_net_stress_route
       - ltp_net_tcp_cmds
       - ltp_net_tirpc_tests
-      - ltp_numa
+      - ltp_numa:
+          settings:
+            LTP_TAINT_EXPECTED: '0x200'
       - ltp_openposix:
           priority: 50
       - ltp_power_management_tests
@@ -423,7 +431,9 @@ scenarios:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
       - ltp_tracing
-      - ltp_uevent
+      - ltp_uevent:
+          settings:
+            LTP_TAINT_EXPECTED: '0x200'
       - ltp_watchqueue
       - nfs_cthon04-nfs3
       - nfs_cthon04-nfs4


### PR DESCRIPTION
ltp_mm, ltp_mm_oom, ltp_numa, ltp_uevent on x86_64 need LTP_TAINT_EXPECTED=0x200 to avoid Kernel issued warning.

aarch64 and ppc64le don't issue these taints, s390x don't test them, thus not adding this setup.

ltp_mm is tested also on i586, where it's not needed atm, but overcommit_memory0[1-6] fail. Likely, once these tests are fixed, they will issue the same taint, thus set it now.

See:
* https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20240825&groupid=32
* https://openqa.opensuse.org/tests/overview?distri=opensuse&version=Tumbleweed&build=20240823&groupid=32
* 
@Vogtinator @mdoucha FYI