### PR TITLE
Update product for Leap 16.0 (add -Leap suffix)

### DIFF
--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -14,13 +14,13 @@ defaults:
     machine: 64bit-2G
     priority: 55
 products:
-  opensuse-agama-installer-x86_64:
+  opensuse-agama-installer-Leap-x86_64:
     distri: opensuse
-    flavor: agama-installer
+    flavor: agama-installer-Leap
     version: '16.0'
 scenarios:
   x86_64:
-    opensuse-agama-installer-x86_64:
+    opensuse-agama-installer-Leap-x86_64:
       - gnome-agama:
           machine: uefi-3G
       - gnome-agama:


### PR DESCRIPTION
We will use agama-installer-openSUSE flavor / package name to avoid conflicting with install image from TW and Devproject. Deets in https://github.com/os-autoinst/openqa-trigger-from-obs/pull/259/files