### PR TITLE
staging_projects.yaml: Use uefi-staging for MicroOS-Image-sdboot

### DIFF
--- a/job_groups/staging_projects.yaml
+++ b/job_groups/staging_projects.yaml
@@ -145,7 +145,7 @@ scenarios:
     microos-*-Staging-MicroOS-Image-sdboot-x86_64:
       - microos-wizard-tpm:
           testsuite: microos-wizard
-          machine: uefi
+          machine: uefi-staging
           settings:
             # jeos-firstboot sets up FDE by default
             ENCRYPT: '1'


### PR DESCRIPTION
Otherwise it fails to boot.