### PR TITLE
Leap 15.6: Add missing LTP_TAINT_EXPECTED LTP

### DIFF
--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -96,6 +96,8 @@ scenarios:
           machine: 64bit_virtio-2G
       - jeos-ltp-commands:
           machine: 64bit_virtio
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-containers:
           machine: 64bit_virtio
       - jeos-ltp-cve:
@@ -106,6 +108,8 @@ scenarios:
           machine: 64bit_virtio
       - jeos-ltp-syscalls:
           machine: 64bit_virtio
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio
     opensuse-Leap15.6-GNOME-Live-x86_64:
@@ -229,8 +233,12 @@ scenarios:
       - jeos-ltp-containers
       - jeos-ltp-cve
       - jeos-ltp-dio
-      - jeos-ltp-syscalls
-      - jeos-ltp-commands
+      - jeos-ltp-syscalls:
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
+      - jeos-ltp-commands:
+          settings:
+            LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc
     opensuse-15.6-JeOS-for-RPi-aarch64:
       - jeos:


### PR DESCRIPTION
The reason is the same as for 0648342, it should have been in that commit.

Fixes: 0648342 ("Leap: Set LTP_TAINT_EXPECTED for LTP tests")