### PR TITLE
Add agama_kde test suite into Leap 16.0 job group

### DIFF
--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -29,5 +29,11 @@ scenarios:
           machine: uefi-usb-4G
       - gnome-agama:
           machine: USBboot_64-3G
-      - mediacheck:
-          machine: 64bit
+      - kde-agama:
+          machine: uefi-3G
+      - kde-agama:
+          machine: 64bit-3G
+      - kde-agama:
+          machine: uefi-usb-4G
+      - kde-agama:
+          machine: USBboot_64-3G


### PR DESCRIPTION
* drop mediacheck which is not yet implemented
* test suite kde_agama was already created in https://openqa.opensuse.org/admin/test_suites