### PR TITLE
Add zdup from 15.6 to Leap 16.0 poo#166562

### DIFF
--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -37,3 +37,5 @@ scenarios:
           machine: uefi-usb-4G
       - kde-agama:
           machine: USBboot_64-3G
+      - zdup-Leap-15.6-gnome
+      - zdup-Leap-15.6-kde


### PR DESCRIPTION
Let's add 15.6 -> 16.0 migration test for GNOME and KDE
Issue tracker: https://progress.opensuse.org/issues/166562

I see that somebody already created  test suites for these, and since there is no 15.7 we can use them to migrate directly to 16.0

![image](https://github.com/user-attachments/assets/662619c8-3331-4564-849e-b430273f0c54)
