### PR TITLE
Remove podman_testsuite from aarch64

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -282,28 +282,6 @@ scenarios:
           settings:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
-      - containers_host_podman_testsuite:
-          description: |-
-            Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
-          testsuite: extra_tests_textmode_containers
-          settings:
-            CONTAINER_RUNTIMES: 'podman'
-            MAX_JOB_TIME: '12000'
-            QEMUCPUS: '2'
-            QEMURAM: '2048'
-            AARDVARK_BATS_SKIP: 'none'
-            NETAVARK_BATS_SKIP: '001-basic 500-plugin'
-            PODMAN_BATS_SKIP: '125-import'
-            PODMAN_BATS_SKIP_ROOT_LOCAL: '010-images 030-run 120-load 255-auto-update'
-            PODMAN_BATS_SKIP_ROOT_REMOTE: 'none'
-            PODMAN_BATS_SKIP_USER_LOCAL: '070-build 200-pod 505-networking-pasta'
-            PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
-            RUNC_BATS_SKIP: 'update'
-            RUNC_BATS_SKIP_ROOT: 'cgroups'
-            RUNC_BATS_SKIP_USER: 'none'
-            SKOPEO_BATS_SKIP: 'none'
-            SKOPEO_BATS_SKIP_USER: 'none'
-            SKOPEO_BATS_SKIP_ROOT: 'none'
       - containers_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Remove podman_testsuite from aarch64.  Will be re-enabled when we have ARM workers.