### PR TITLE
Run podman testsuite on its own job

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -335,14 +335,22 @@ scenarios:
             CONTAINER_RUNTIMES: 'podman'
             MAX_JOB_TIME: '12000'
             QEMUCPUS: '2'
-            QEMURAM: '2048'
-            AARDVARK_BATS_SKIP: 'none'
-            NETAVARK_BATS_SKIP: '001-basic 250-bridge-nftables 500-plugin'
+            QEMURAM: '4096'
             PODMAN_BATS_SKIP: '125-import'
             PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 271-tcp-cors-server'
             PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio'
             PODMAN_BATS_SKIP_USER_LOCAL: '200-pod 271-tcp-cors-server 505-networking-pasta'
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
+      - containers_host_bats_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            QEMUCPUS: '2'
+            QEMURAM: '4096'
+            AARDVARK_BATS_SKIP: 'none'
+            NETAVARK_BATS_SKIP: '001-basic 250-bridge-nftables 500-plugin'
             RUNC_BATS_SKIP: 'none'
             RUNC_BATS_SKIP_ROOT: 'none'
             RUNC_BATS_SKIP_USER: 'none'


### PR DESCRIPTION
Run podman testsuite on its own job as it takes very long.

Related to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20359
