### PR TITLE
Separate the tests that require large disks.

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -433,6 +433,7 @@ scenarios:
       - xfstests_btrfs-btrfs-001-100
       - xfstests_btrfs-btrfs-101-200
       - xfstests_btrfs-btrfs-201-999
+      - xfstests_btrfs-btrfs-big_size
       - xfstests_btrfs-generic-001-100
       - xfstests_xfs-generic-001-100
       - xfstests_xfs-xfs-001-100


### PR DESCRIPTION
btrfs supports RAID, so generally we need 6 partitions for testing. Typically, these partitions are of equal size. However, some tests only require one or
 two partitions and demand larger space.
Therefore add xfstests_btrfs-btrfs-big_size with 8192M scratch_dev1