### PR TITLE
Schedule container-host tests for RISC-V

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -25,6 +25,10 @@ scenarios:
       - jeos:
           settings:
             EXCLUDE_MODULES: libzypp_config
+      - jeos-container_host:
+          settings:
+            # Note: docker still has some issues in validate_btrfs
+            CONTAINER_RUNTIMES: 'podman'
       - jeos-ltp-commands:
           settings:
             EXCLUDE_MODULES: libzypp_config


### PR DESCRIPTION
Schedule the container-hosts tests for RISC-V.

* Verification run: https://openqa.opensuse.org/tests/4637580
* Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20448
* Related ticket: https://openqa.opensuse.org/tests/4645110