### PR TITLE
Set QEMUCPUS=1 for bats_testsuite

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -347,7 +347,6 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
-            QEMUCPUS: '2'
             QEMURAM: '4096'
             AARDVARK_BATS_SKIP: 'none'
             NETAVARK_BATS_SKIP: '001-basic 250-bridge-nftables 500-plugin'


### PR DESCRIPTION
Set QEMUCPUS=1 for bats_testsuite.  With QEMUCPUS=2 the runc test fails for some unknown reason.

VR: https://openqa.suse.de/tests/15647584