### PR TITLE
LTP: tw: aarch64: Add expected taint flag for RPi4

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -645,6 +645,7 @@ scenarios:
           machine: RPi4
           settings:
             PASSWORD: linux
+            LTP_TAINT_EXPECTED: '0x80013c01'
       - qemu:
           machine: RPi4
           settings:


### PR DESCRIPTION
Using usual value 0x80013801 (see a68add8) | 0x400 (Staging driver was loaded, this is RPi specific).

- Verification run: https://openqa.opensuse.org/tests/4551926#step/shutdown_ltp/12