### PR TITLE
LTP: Be more strict on LTP_TAINT_EXPECTED

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -917,7 +917,7 @@ scenarios:
       - jeos-ltp-commands:
           machine: RPi4
           settings:
-            LTP_TAINT_EXPECTED: '0x13c01'
+            LTP_TAINT_EXPECTED: '0x3400'
             PASSWORD: linux
       - jeos-ltp-containers:
           machine: RPi4
@@ -928,11 +928,11 @@ scenarios:
           machine: RPi4
           settings:
             PASSWORD: linux
-            LTP_TAINT_EXPECTED: '0x13c01'
+            LTP_TAINT_EXPECTED: '0x400'
       - jeos-ltp-syscalls:
           machine: RPi4
           settings:
-            LTP_TAINT_EXPECTED: '0x13c01'
+            LTP_TAINT_EXPECTED: '0x3400'
             PASSWORD: linux
       - qemu:
           machine: RPi4


### PR DESCRIPTION
jeos-ltp-containers and jeos-ltp-cve need only 0x400:
- Staging driver was loaded (0x400, 1 << 10)

jeos-ltp-commands and jeos-ltp-syscalls and need only 0x3400:
- Staging driver was loaded (0x400, 1 << 10)
- Out of tree module was loaded (0x1000, 1 << 12)
- Unsigned module was loaded (0x2000, 1 << 13)

Fixes: 21c07ab ("Tumbleweed: RPi4: Add LTP containers, commands, syscalls")
Fixes: d880cd2 ("LTP: tw: aarch64: Minimize LTP_TAINT_EXPECTED value for cve")