### PR TITLE
Use QEMUCPU=host for buildah upstream tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -365,6 +365,8 @@ scenarios:
             Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
           settings:
             CONTAINER_RUNTIMES: 'podman'
+            QEMUCPU: 'host'
+            MAX_JOB_TIME: '12000'
             BUILDAH_BATS_SKIP: 'commit run'
             BUILDAH_BATS_SKIP_ROOT: 'none'
             BUILDAH_BATS_SKIP_USER: 'add basic bud copy overlay rmi sbom squash'


### PR DESCRIPTION
We need this setting for 15-SP6 for chroot subtest.

Related MR: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1881