### PR TITLE
Add cgroups to RUNC_BATS_SKIP_ROOT

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -354,7 +354,7 @@ scenarios:
             CONTAINER_RUNTIMES: 'podman'
             QEMURAM: '4096'
             RUNC_BATS_SKIP: 'none'
-            RUNC_BATS_SKIP_ROOT: 'none'
+            RUNC_BATS_SKIP_ROOT: 'cgroups'
             RUNC_BATS_SKIP_USER: 'update'
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_USER: 'none'


### PR DESCRIPTION
This issue with BFQ scheduler is seen when running on wrong worker.

Fix for https://openqa.opensuse.org/tests/4605219