### PR TITLE
Schedule "jeos-nosb" in TW, Leap 15.5 and 15.6

### DIFF
--- a/job_groups/opensuse_leap_15.5_images.yaml
+++ b/job_groups/opensuse_leap_15.5_images.yaml
@@ -110,6 +110,8 @@ scenarios:
             LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio
+      - jeos-nosb:
+          machine: uefi_virtio-2G
     opensuse-Leap15.5-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi-3G
@@ -250,6 +252,7 @@ scenarios:
           settings:
             LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc
+      - jeos-nosb
     opensuse-15.5-JeOS-for-RPi-aarch64:
       - jeos:
           machine: RPi3

--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -112,6 +112,8 @@ scenarios:
             LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc:
           machine: 64bit_virtio
+      - jeos-nosb:
+          machine: uefi_virtio-2G
     opensuse-Leap15.6-GNOME-Live-x86_64:
       - gnome-live:
           machine: uefi-3G
@@ -240,6 +242,7 @@ scenarios:
           settings:
             LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc
+      - jeos-nosb
     opensuse-15.6-JeOS-for-RPi-aarch64:
       - jeos:
           machine: RPi3

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1294,6 +1294,8 @@ scenarios:
           settings:
             PARALLEL_WITH: jeos-ssh-enroll-server
             YAML_SCHEDULE: schedule/jeos/ssh-enroll.yaml
+      - jeos-nosb:
+          machine: uefi_virtio-2G
     opensuse-Tumbleweed-KDE-Live-x86_64:
       - kde-live:
           machine: uefi-3G

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -890,6 +890,8 @@ scenarios:
       - zdup_twjeos2twnext_aarch64:
           machine: aarch64-HD20G
           priority: 45
+      - jeos-nosb:
+          machine: aarch64-HD20G
     opensuse-Tumbleweed-JeOS-for-RPi-aarch64:
       - jeos:
           machine: RPi3


### PR DESCRIPTION
This is a basic JeOS test that runs with Secure Boot disabled.

- Related ticket: https://progress.opensuse.org/issues/95434
- Verification runs: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20568