### PR TITLE
Tumbleweed aarch64: Remove 'jeos-nosb' from schedule

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -883,8 +883,6 @@ scenarios:
       - zdup_twjeos2twnext_aarch64:
           machine: aarch64-HD20G
           priority: 45
-      - jeos-nosb:
-          machine: aarch64-HD20G
     opensuse-Tumbleweed-JeOS-for-RPi-aarch64:
       - jeos:
           machine: RPi3


### PR DESCRIPTION
There is no need to schedule this test in the product. The machine aarch64-HD20G already have Secure Boot disabled:

https://openqa.opensuse.org/tests/4642213#step/bootloader_uefi/9

- Related tickets:
https://progress.opensuse.org/issues/169846
https://progress.opensuse.org/issues/95434
