### PR TITLE
rename testsuite according to existing name pattern

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -102,7 +102,7 @@ scenarios:
       - ltp_kernel_misc:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
-      - ltp_kernel_warn_tests
+      - ltp_kernel_misc_warns
       - ltp_lvm
       - ltp_math
       - ltp_mm
@@ -262,7 +262,7 @@ scenarios:
       - ltp_kernel_misc:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
-      - ltp_kernel_warn_tests
+      - ltp_kernel_misc_warns
       - ltp_lvm
       - ltp_math
       - ltp_mm
@@ -323,7 +323,7 @@ scenarios:
       - ltp_kernel_misc:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
-      - ltp_kernel_warn_tests
+      - ltp_kernel_misc_warns
       - ltp_lvm
       - ltp_net_features
       - ltp_net_nfs
@@ -384,7 +384,7 @@ scenarios:
       - ltp_kernel_misc:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
-      - ltp_kernel_warn_tests
+      - ltp_kernel_misc_warns
       - ltp_lvm
       - ltp_math
       - ltp_mm


### PR DESCRIPTION
follow up from Commit 1ea6d97
(LTP: TW: schedule tests which produce kernel warning)