### PR TITLE
Fix container-host for RISC-V

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -27,6 +27,7 @@ scenarios:
             EXCLUDE_MODULES: libzypp_config
       - jeos-container_host:
           settings:
+            BOOT_HDD_IMAGE: '1'
             # Note: docker still has some issues in validate_btrfs
             CONTAINER_RUNTIMES: 'podman'
       - jeos-ltp-commands:


### PR DESCRIPTION
Adds missing job group setting to fix the bootloader module, which is stuck. It is stuck because of the missing BOOT_FROM_HDD setting.

* Related failure: https://openqa.opensuse.org/tests/4663472
* Verification run: https://openqa.opensuse.org/tests/4663602