### PR TITLE
Fix Base-RT-SelfInstall

### DIFF
--- a/job_groups/opensuse_leap_micro_6.x_dvd.yaml
+++ b/job_groups/opensuse_leap_micro_6.x_dvd.yaml
@@ -154,7 +154,7 @@ scenarios:
     leap-micro-6.1-Base-RT-SelfInstall-x86_64:
       - microos_image_default:
           settings:
-            <<: *image_settings
+            <<: *selfinstall_settings
   aarch64:
     leap-micro-6.1-Default-aarch64:
       - microos_image_default:


### PR DESCRIPTION
Base-RT SelfInstall should use the selfinstall yaml anchors, not the image-based settings.

* Related failure: https://openqa.opensuse.org/tests/4664456
* Verification run: https://openqa.opensuse.org/tests/4666795