### PR TITLE
Ignore 520-checkpoint failure in podman upstream tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -334,10 +334,10 @@ scenarios:
             MAX_JOB_TIME: '12000'
             QEMUCPUS: '2'
             QEMURAM: '4096'
-            PODMAN_BATS_SKIP: '125-import'
-            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 180-blkio 271-tcp-cors-server'
-            PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio'
-            PODMAN_BATS_SKIP_USER_LOCAL: '200-pod 271-tcp-cors-server 505-networking-pasta'
+            PODMAN_BATS_SKIP: 'none'
+            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 180-blkio 520-checkpoint'
+            PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio 520-checkpoint'
+            PODMAN_BATS_SKIP_USER_LOCAL: '505-networking-pasta'
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - containers_host_bats_testsuite:
           description: |-


### PR DESCRIPTION
Ignore 520-checkpoint failure in podman upstream tests

Related ticket: https://progress.opensuse.org/issues/173362

```
$ susebats notok https://openqa.opensuse.org/tests/4677818
PODMAN_BATS_SKIP='none'
PODMAN_BATS_SKIP_ROOT_LOCAL='120-load 520-checkpoint'
PODMAN_BATS_SKIP_ROOT_REMOTE='520-checkpoint'
PODMAN_BATS_SKIP_USER_LOCAL='505-networking-pasta'
PODMAN_BATS_SKIP_USER_REMOTE='505-networking-pasta'
```