### PR TITLE
Update mariadb marker

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -538,7 +538,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: mariadb-client_11.5
+            BCI_IMAGE_MARKER: mariadb-client_11.6
             BCI_TEST_ENVS: all,mariadb,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/mariadb-client:latest
       - bci_389-ds_3.1_podman:


### PR DESCRIPTION
The containerized MariaDB client got updated, so the marker needs to be updated as well.

* Related ticket: https://progress.opensuse.org/issues/170377
* Related failure: https://openqa.opensuse.org/tests/4668972
* Verification run: https://openqa.opensuse.org/tests/4682894