### PR TITLE
kernel: remove udev-no-partlabel-links test for TW

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -433,7 +433,6 @@ scenarios:
       - nfs_cthon04-nfs4
       - nfs_pynfs_nfs40_all
       - nfs_pynfs_nfs41_all
-      - udev-no-partlabel-links
       - create_hdd_xfstests
       - xfstests_btrfs-btrfs-001-100
       - xfstests_btrfs-btrfs-101-200


### PR DESCRIPTION
We received the confirmation that this issue/test should be ignored on TW [1]

[1] https://bugzilla.suse.com/show_bug.cgi?id=1234114#c2