### PR TITLE
Add BCI_DEVEL_REPO

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -26,6 +26,8 @@
   BCI_TARGET: "factory-totest"
   # match -> opensuse-Tumbleweed-x86_64-20240603-textmode@64bit.qcow2
   HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
+  # %DISTRI% is opensuse but we need openSUSE
+  BCI_DEVEL_REPO: 'http://openqa.opensuse.org/assets/repo/openSUSE-%VERSION%-oss-%ARCH%-Snapshot%BUILD%'
   +FLAVOR: 'BCI'
 
 defaults:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -26,6 +26,8 @@
   BCI_TARGET: "factory-arm-totest"
   # match -> opensuse-Tumbleweed-x86_64-20240603-textmode@64bit.qcow2
   HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
+  # %DISTRI% is opensuse but we need openSUSE
+  BCI_DEVEL_REPO: 'http://openqa.opensuse.org/assets/repo/openSUSE-%VERSION%-oss-%ARCH%-Snapshot%BUILD%'
   +FLAVOR: 'BCI'
 
 defaults:


### PR DESCRIPTION
Adds the BCI_DEVEL_REPO setting to include the current TW snapshot repository in the BCI containers.

* Related ticket: https://progress.opensuse.org/issues/167716
* Verification run: https://openqa.opensuse.org/tests/4683454 (Cloned and applying the settings manually)