### PR TITLE
Fix Base-RT-SelfInstall and rename Leap-Micro job groups

### DIFF
--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -62,8 +62,8 @@
 98: opensuse_leap_15.4_updates
 99: opensuse_leap_15.4_backports
 100: alp
-101: opensuse_leap_micro_6.x_image
-102: opensuse_leap_micro_6.x_dvd
+101: opensuse_leap_micro_6.0
+102: opensuse_leap_micro_6.1
 103: opensuse_leap_15.5_images
 104: opensuse_leap_15.5_armv7_images
 105: alp-staging

--- a/job_groups/opensuse_leap_micro_6.0.yaml
+++ b/job_groups/opensuse_leap_micro_6.0.yaml
@@ -5,7 +5,7 @@
 #  Any changes via the openQA WebUI will get overwritten!  #
 #                                                          #
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
-#      job_groups/opensuse_leap_micro_6.x_image.yaml       #
+#         job_groups/opensuse_leap_micro_6.0.yaml          #
 ############################################################
 ---
 .default_settings: &default_settings

--- a/job_groups/opensuse_leap_micro_6.1.yaml
+++ b/job_groups/opensuse_leap_micro_6.1.yaml
@@ -5,7 +5,7 @@
 #  Any changes via the openQA WebUI will get overwritten!  #
 #                                                          #
 #    https://github.com/os-autoinst/opensuse-jobgroups     #
-#       job_groups/opensuse_leap_micro_6.x_dvd.yaml        #
+#         job_groups/opensuse_leap_micro_6.1.yaml          #
 ############################################################
 ---
 .default_settings: &default_settings

--- a/job_groups/opensuse_leap_micro_6.x_dvd.yaml
+++ b/job_groups/opensuse_leap_micro_6.x_dvd.yaml
@@ -155,9 +155,9 @@ scenarios:
           settings:
             <<: *image_settings
     leap-micro-6.1-Base-RT-SelfInstall-x86_64:
-      - microos_image_default:
+      - microos_installation_default:
           settings:
-            <<: *selfinstall_settings
+            <<: *image_settings
   aarch64:
     leap-micro-6.1-Default-aarch64:
       - microos_image_default:


### PR DESCRIPTION
* Use the SelfInstall settings and not the Image settings.
* Make filenames of Leap-Micro match with new job group names in O3.