### PR TITLE
Fix SelfInstall on 6.1

### DIFF
--- a/job_groups/opensuse_leap_micro_6.1.yaml
+++ b/job_groups/opensuse_leap_micro_6.1.yaml
@@ -157,7 +157,7 @@ scenarios:
     leap-micro-6.1-Base-RT-SelfInstall-x86_64:
       - microos_installation_default:
           settings:
-            <<: *image_settings
+            <<: *selfinstall_settings
   aarch64:
     leap-micro-6.1-Default-aarch64:
       - microos_image_default:


### PR DESCRIPTION
Fix also the SelfInstall settings on 6.1, same way as we did it with 6.0.