### PR TITLE
Update prometheus from version 2 to 3

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -515,11 +515,11 @@ scenarios:
             BCI_TEST_ENVS: all,openjdk,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/openjdk:21
       ### application containers
-      - bci_prometheus_2_podman:
+      - bci_prometheus_3_podman:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: prometheus_2
+            BCI_IMAGE_MARKER: prometheus_3
             BCI_TEST_ENVS: prometheus,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/prometheus:latest
       - bci_spack_podman:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -452,11 +452,11 @@ scenarios:
             BCI_TEST_ENVS: all,openjdk,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/openjdk:21
       ### application containers
-      - bci_prometheus_2_podman:
+      - bci_prometheus_3_podman:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: prometheus_2
+            BCI_IMAGE_MARKER: prometheus_3
             BCI_TEST_ENVS: prometheus,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/prometheus:latest
       - bci_spack_podman:


### PR DESCRIPTION
The prometheus application has been updated.

* Related PR: https://github.com/SUSE/BCI-tests/pull/689
* Verification run: https://openqa.opensuse.org/tests/4692951