### PR TITLE
Update kiwi marker to latest

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -561,7 +561,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: kiwi_10.1
+            BCI_IMAGE_MARKER: kiwi_latest
             BCI_TEST_ENVS: all,kiwi,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/kiwi:latest
       - bci_postgres_14_podman:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -498,7 +498,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: kiwi_10.1
+            BCI_IMAGE_MARKER: kiwi_latest
             BCI_TEST_ENVS: all,kiwi,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/kiwi:latest
       - bci_postgres_14_podman:


### PR DESCRIPTION
Kiwi is now `latest`.

Verification run: https://openqa.opensuse.org/tests/4695069