### PR TITLE
Enable docker on RISC-V

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -25,11 +25,15 @@ scenarios:
       - jeos:
           settings:
             EXCLUDE_MODULES: libzypp_config
-      - jeos-container_host:
+      - jeos-container_host_podman:
           settings:
             BOOT_HDD_IMAGE: '1'
-            # Note: docker still has some issues in validate_btrfs
             CONTAINER_RUNTIMES: 'podman'
+      - jeos-container_host_docker:
+          settings:
+            BOOT_HDD_IMAGE: '1'
+            CONTAINER_RUNTIMES: 'docker'
+            EXCLUDE_MODULES: 'rootless_docker,validate_btrfs'
       - jeos-ltp-commands:
           settings:
             EXCLUDE_MODULES: libzypp_config


### PR DESCRIPTION
Enable docker test runs for RISC-V.

* Related ticket: https://progress.opensuse.org/issues/166589
* Verification run: https://openqa.opensuse.org/tests/4706302