### PR TITLE
Test podman & docker with AppArmor & SELinux

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -316,21 +316,42 @@ scenarios:
       - extra_tests_on_xfce
       - extra_tests_textmode
       - extra_tests_webserver
-      - container_host_docker:
+      - container_host_docker_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'docker'
-      - container_host_podman:
+            SECURITY_MAC: 'apparmor'
+      - container_host_docker_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'docker'
+            SECURITY_MAC: 'selinux'
+      - container_host_podman_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
-      - containers_host_podman_runc:
+            SECURITY_MAC: 'apparmor'
+      - containers_host_podman_runc_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
             OCI_RUNTIME: 'runc'
+            SECURITY_MAC: 'apparmor'
+      - container_host_podman_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            SECURITY_MAC: 'selinux'
+      - containers_host_podman_runc_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            OCI_RUNTIME: 'runc'
+            SECURITY_MAC: 'selinux'
       - container_host_podman_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -287,10 +287,16 @@ scenarios:
       - gnome-ext4
       - extra_tests_textmode
       - extra_tests_misc
-      - container_host_docker:
+      - container_host_docker_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'docker'
+            SECURITY_MAC: 'apparmor'
+      - container_host_docker_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'docker'
+            SECURITY_MAC: 'selinux'
       - container_host_helm:
           testsuite: extra_tests_textmode_containers
           settings:
@@ -302,17 +308,32 @@ scenarios:
             CONTAINER_RUNTIMES: 'kubectl'
             K3S_INSTALL_UPSTREAM: '1'
             K3S_ENABLE_COREDNS: '1'
-      - container_host_podman:
+      - container_host_podman_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
-      - container_host_podman_runc:
+            SECURITY_MAC: 'apparmor'
+      - container_host_podman_runc_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
             K3S_INSTALL_UPSTREAM: '1'
             OCI_RUNTIME: 'runc'
+            SECURITY_MAC: 'apparmor'
+      - container_host_podman_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            SECURITY_MAC: 'selinux'
+      - container_host_podman_runc_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            CONTAINER_RUNTIMES: 'podman'
+            K3S_INSTALL_UPSTREAM: '1'
+            OCI_RUNTIME: 'runc'
+            SECURITY_MAC: 'selinux'
       - container_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Add test runs for AppArmor & SELinux on podman (using crun & runc as runtime) & docker.

Verification runs (x86_64 only):
  - Tumbleweed (podman w/ `SECURITY_MAC=selinux`): https://openqa.opensuse.org/tests/4706320
  - Tumbleweed (podman w/ `SECURITY_MAC=apparmor`): https://openqa.opensuse.org/tests/4706338
  - Tumbleweed (docker w/ `SECURITY_MAC=selinux`): https://openqa.opensuse.org/tests/4706453

Related ticket: https://progress.opensuse.org/issues/168682