### PR TITLE
Reverse the order of CONTAINER_RUNTIMES for containers_image test

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -412,7 +412,7 @@ scenarios:
       - containers_image:
           testsuite: extra_tests_textmode_containers
           settings:
-            CONTAINER_RUNTIMES: 'docker,podman'
+            CONTAINER_RUNTIMES: 'podman,docker'
             K3S_INSTALL_UPSTREAM: '1'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -345,7 +345,7 @@ scenarios:
       - containers_image:
           testsuite: extra_tests_textmode_containers
           settings:
-            CONTAINER_RUNTIMES: 'docker,podman'
+            CONTAINER_RUNTIMES: 'podman,docker'
             CONTAINERS_UNTESTED_IMAGES: '1'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/173362

docker still uses iptables as backend and hasn't migrated to nftables yet.
https://github.com/docker/for-linux/issues/1472