### PR TITLE
Update BCI ruby marker

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -474,7 +474,7 @@ scenarios:
           settings:
             <<: *bci
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/ruby:latest
-            BCI_IMAGE_MARKER: ruby_3.3
+            BCI_IMAGE_MARKER: ruby_3.4
             BCI_TEST_ENVS: ruby
       - bci_gcc_13_podman:
           testsuite: null

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -407,7 +407,7 @@ scenarios:
           settings:
             <<: *bci
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/ruby:latest
-            BCI_IMAGE_MARKER: ruby_3.3
+            BCI_IMAGE_MARKER: ruby_3.4
             BCI_TEST_ENVS: ruby
       - bci_gcc_13_podman:
           testsuite: null


### PR DESCRIPTION
The Ruby container has been updated to 3.4.

* Related failure: https://openqa.opensuse.org/tests/4766684
* Verification run: https://openqa.opensuse.org/tests/4769236