### PR TITLE
Update BCI to latest states

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -474,7 +474,7 @@ scenarios:
           settings:
             <<: *bci
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/ruby:latest
-            BCI_IMAGE_MARKER: ruby_3.4
+            BCI_IMAGE_MARKER: ruby_latest
             BCI_TEST_ENVS: ruby
       - bci_gcc_13_podman:
           testsuite: null

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -490,13 +490,6 @@ scenarios:
             BCI_IMAGE_MARKER: gcc_14
             BCI_TEST_ENVS: gcc
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/gcc:14
-      - bci_python_3.10_podman:
-          testsuite: null
-          settings:
-            <<: *bci
-            BCI_IMAGE_MARKER: python_3.10
-            BCI_TEST_ENVS: python
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/python:3.10
       - bci_python_3.11_podman:
           testsuite: null
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -407,7 +407,7 @@ scenarios:
           settings:
             <<: *bci
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/ruby:latest
-            BCI_IMAGE_MARKER: ruby_3.4
+            BCI_IMAGE_MARKER: ruby_latest
             BCI_TEST_ENVS: ruby
       - bci_gcc_13_podman:
           testsuite: null

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -423,13 +423,6 @@ scenarios:
             BCI_IMAGE_MARKER: gcc_14
             BCI_TEST_ENVS: gcc
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/gcc:14
-      - bci_python_3.10_podman:
-          testsuite: null
-          settings:
-            <<: *bci
-            BCI_IMAGE_MARKER: python_3.10
-            BCI_TEST_ENVS: python
-            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/python:3.10
       - bci_python_3.11_podman:
           testsuite: null
           settings:


### PR DESCRIPTION
Switch to a versionless ruby string and remove the Python 3.10 test runs because it doesn't exist anymore.

* Related ticket: https://progress.opensuse.org/issues/175233
* Related failures: https://openqa.opensuse.org/tests/4769955 https://openqa.opensuse.org/tests/4769152
* VR: https://openqa.opensuse.org/tests/4770898 https://openqa.opensuse.org/tests/4770899
* Follow-up of https://github.com/SUSE/BCI-tests/pull/724