### PR TITLE
Increase memory for MicroOS

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -113,12 +113,12 @@ scenarios:
           machine: 64bit
       - microos_textmode
       - container_host:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
       - fips-container_host:
-          machine: 64bit
+          machine: 64bit-2G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'


### PR DESCRIPTION
Increase the runtime memory for the YaST-based installer test runs to 2G. This is needed because of memory issues with less memory, see bsc#1234775.

aarch64 is not affected, because it uses already a machine with 4GiB of system memory.

* Related tickets:https://progress.opensuse.org/issues/175827 https://bugzilla.opensuse.org/show_bug.cgi?id=1234775
* Related failure: https://openqa.opensuse.org/tests/4791261#settings
* Verification run: https://openqa.opensuse.org/tests/4794713#step/await_install/4