### PR TITLE
Disable 520-checkpoint in podman

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -362,8 +362,8 @@ scenarios:
             QEMUCPUS: '2'
             QEMURAM: '4096'
             PODMAN_BATS_SKIP: 'none'
-            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 180-blkio'
-            PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio'
+            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 180-blkio 520-checkpoint'
+            PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio 520-checkpoint'
             PODMAN_BATS_SKIP_USER_LOCAL: '505-networking-pasta'
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_bats_testsuite:


### PR DESCRIPTION
This subtest may fail on certain Intel processors:
https://access.redhat.com/solutions/7009067

Failing test: https://openqa.opensuse.org/tests/4804407#