### PR TITLE
Force platform_intel temporarily

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1541,7 +1541,7 @@ scenarios:
             WSL2: '1'
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
-            WORKER_CLASS: 'wsl2'
+            WORKER_CLASS: 'wsl2, platform_intel'  # force platform_intel, temporary fix bsc#1234635'
       - wsl2-install-msstore:
           <<: *wsl2_test
           description: |


### PR DESCRIPTION
Temporarily force wsl2 testing to be done only on intel workers.

Per https://progress.opensuse.org/issues/174811 windows boot is failing on many amd workers. 

There is a kernel fix on the way here: https://build.suse.de/request/show/358483 as a result of this bug: https://bugzilla.suse.com/show_bug.cgi?id=1234635

Once the kernel fix is deployed in openQA workers, WORKER_CLASS=platform_intel should be removed.