### PR TITLE
job_groups/opensuse_leap_15.6_images.yaml: Remove jeos-nosb from aarch64

### DIFF
--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -242,7 +242,6 @@ scenarios:
           settings:
             LTP_TAINT_EXPECTED: '0x80013801'
       - jeos-ltp-syscalls-ipc
-      - jeos-nosb
     opensuse-15.6-JeOS-for-RPi-aarch64:
       - jeos:
           machine: RPi3


### PR DESCRIPTION
The aarch64 tests all run with SB disabled.

https://progress.opensuse.org/issues/176301