### PR TITLE
Make name consistent

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -551,7 +551,7 @@ scenarios:
             BCI_IMAGE_MARKER: spack
             BCI_TEST_ENVS: all,spack,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/spack:latest
-      - bci_alertmanager_latest_podman:
+      - bci_alertmanager_podman:
           testsuite: null
           settings:
             <<: *bci

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -480,7 +480,7 @@ scenarios:
             BCI_IMAGE_MARKER: spack
             BCI_TEST_ENVS: all,spack,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/spack:latest
-      - bci_alertmanager_latest_podman:
+      - bci_alertmanager_podman:
           testsuite: null
           settings:
             <<: *bci


### PR DESCRIPTION
Remove the latest from the container name to make it consistent with the other BCI jobs.

* Follow-up of https://github.com/os-autoinst/opensuse-jobgroups/pull/587