### PR TITLE
Tumbleweed: Introduce explicit {gnome,kde,textmode}+apparmor jobs

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -289,10 +289,22 @@ scenarios:
       - minimalx_btrfs_snapper
       - create_hdd_textmode:
           priority: 45
+      - create_hdd_textmode_apparmor:
+          priority: 45
+          testsuite: 'create_hdd_textmode'
+          settings:
+            SELINUX: '0'
+            PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - create_hdd_textmode_autoyast:
           priority: 45
       - create_hdd_gnome:
           priority: 45
+      - create_hdd_gnome_apparmor:
+          priority: 45
+          testsuite: 'create_hdd_gnome'
+          settings:
+            SELINUX: '0'
+            PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - create_hdd_gnome_libyui
       - create_hdd_gnome_wicked
       - create_hdd_kde:
@@ -308,7 +320,10 @@ scenarios:
       - yast2_nfs_v4_client
       - yast2_ui_devel
       - yast2_users
-      - yast2_apparmor
+      - yast2_apparmor:
+          settings:
+            START_AFTER_TEST: 'create_hdd_gnome_apparmor'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - extra_tests_gnome
       - create_hdd_xfce:
           priority: 46
@@ -805,7 +820,10 @@ scenarios:
             YAML_SCHEDULE: schedule/yast/opensuse/xfs/xfs_textmode.yaml
             YAML_TEST_DATA: test_data/yast/opensuse/xfs/xfs_partition.yaml
           testsuite: null
-      - apparmor
+      - apparmor:
+          settings:
+            START_AFTER_TEST: 'create_hdd_textmode_apparmor'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - security_misc_o3
       - lvm-encrypt-separate-boot:
           machine: 64bit
@@ -1063,7 +1081,10 @@ scenarios:
       - gnome-x11-ibus
       - toolkits-kde
       - openldap_to_389ds
-      - apparmor_profile
+      - apparmor_profile:
+          settings:
+            START_AFTER_TEST: 'create_hdd_gnome_apparmor'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - create_swtpm_hdd
       - create_hdd_textmode_uefi:
           machine: uefi

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1502,6 +1502,21 @@ scenarios:
           machine: uefi
       - textmode+selinux:
           machine: uefi
+      - kde+apparmor:
+          testsuite: kde
+          machine: uefi
+          settings:
+            SELINUX: '0'
+      - gnome+apparmor:
+          testsuite: gnome
+          machine: uefi
+          settings:
+            SELINUX: '0'
+      - textmode+apparmor:
+          testsuite: textmode
+          machine: uefi
+          settings:
+            SELINUX: '0'
     opensuse-Tumbleweed-Rescue-CD-x86_64:
       - rescue:
           priority: 49

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1019,6 +1019,18 @@ scenarios:
       - kde+selinux
       - gnome+selinux
       - textmode+selinux
+      - kde+apparmor:
+          testsuite: kde
+          settings:
+            SELINUX: '0'
+      - gnome+apparmor:
+          testsuite: gnome
+          settings:
+            SELINUX: '0'
+      - textmode+apparmor:
+          testsuite: textmode
+          settings:
+            SELINUX: '0'
     opensuse-Tumbleweed-Rescue-CD-aarch64:
       - rescue:
           machine: USBboot_aarch64

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -264,6 +264,12 @@ scenarios:
             YAML_SCHEDULE: schedule/yast/opensuse/yast2_ncurses/yast2_ncurses.yaml
       - create_hdd_textmode:
           priority: 40
+      - create_hdd_textmode_apparmor:
+          priority: 45
+          testsuite: 'create_hdd_textmode'
+          settings:
+            SELINUX: '0'
+            PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - create_hdd_textmode_autoyast:
           priority: 40
       - create_hdd_textmode:
@@ -671,7 +677,10 @@ scenarios:
       - systemd-networkd
       - system_performance
       - system_check
-      - apparmor
+      - apparmor:
+          settings:
+            START_AFTER_TEST: 'create_hdd_textmode_apparmor'
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%-apparmor@%MACHINE%.qcow2'
       - security_misc_o3
       - zdup-Leap-15.2-gnome
       - openscap


### PR DESCRIPTION
With SELinux by default, we need explicit testing with AppArmor. Use the full testsuites instead of INSTALLONLY=1 for better coverage.

Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21078