### PR TITLE
kernel: Add ltp_ima_load_policy

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -97,6 +97,9 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
+      - ltp_ima_load_policy:
+          settings:
+            LTP_COMMAND_EXCLUDE: ima_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -257,6 +260,9 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
+      - ltp_ima_load_policy:
+          settings:
+            LTP_COMMAND_EXCLUDE: ima_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -379,6 +385,9 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
+      - ltp_ima_load_policy:
+          settings:
+            LTP_COMMAND_EXCLUDE: ima_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:


### PR DESCRIPTION
ima_selinux.sh not ready yet therefore disabled until fixed.

https://progress.opensuse.org/issues/159045

Verification run:
https://openqa.opensuse.org/tests/overview?build=ima (jobs with load_policy.skip-selinux)