### PR TITLE
Increase memory for jeos-extra

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1303,7 +1303,7 @@ scenarios:
       - jeos:
           machine: uefi_virtio-2G
       - jeos-extra:
-          machine: 64bit_virtio-2G
+          machine: 64bit_virtio-4G
       - jeos-apparmor:
           machine: 64bit_virtio-2G
       - jeos-selinux:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -878,6 +878,8 @@ scenarios:
       - jeos-extra:
           machine: aarch64-HD20G
           priority: 45
+          settings:
+            QEMURAM: '4096'
       - jeos-apparmor:
           machine: aarch64-HD20G
       - jeos-container_host:


### PR DESCRIPTION
clamav requires more memory to not fall into a OOM trap. This commit increases the memory size to 4GiB as suggested by the QE-Security team.

* Related ticket: https://progress.opensuse.org/issues/176937
* Verification run: https://openqa.opensuse.org/tests/4849522#