### PR TITLE
Skip post-fail hooks for BCI jobs

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -29,6 +29,7 @@
   # %DISTRI% is opensuse but we need openSUSE
   BCI_DEVEL_REPO: 'http://openqa.opensuse.org/assets/repo/openSUSE-%VERSION%-oss-%ARCH%-Snapshot%BUILD%'
   +FLAVOR: 'BCI'
+  _SKIP_POST_FAIL_HOOKS: '1'
 
 defaults:
   x86_64:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -29,6 +29,7 @@
   # %DISTRI% is opensuse but we need openSUSE
   BCI_DEVEL_REPO: 'http://openqa.opensuse.org/assets/repo/openSUSE-%VERSION%-oss-%ARCH%-Snapshot%BUILD%'
   +FLAVOR: 'BCI'
+  _SKIP_POST_FAIL_HOOKS: '1'
 
 defaults:
   aarch64:


### PR DESCRIPTION
Skip the post-fail hooks that take long and seldom yield anything useful for failed BCI test runs.