### PR TITLE
Fix perl_bootloader on encrypted system

### DIFF
--- a/job_groups/opensuse_leap_micro_6.1.yaml
+++ b/job_groups/opensuse_leap_micro_6.1.yaml
@@ -140,6 +140,9 @@ scenarios:
       - microos_image_default:
           settings:
             <<: *image_settings
+            +FIRST_BOOT_CONFIG: 'wizard'
+            +NUMDISKS: '1'
+            +HDD_2: ''
       - microos_containers:
           settings:
             <<: *image_container_settings


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/175794
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21204
VR: https://openqa.opensuse.org/tests/4854528