### PR TITLE
Enable docker-stable testing for Tumbleweed

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -347,14 +347,24 @@ scenarios:
             CONTAINER_RUNTIMES: 'multi_runtime'
       - container_host_docker_apparmor:
           testsuite: extra_tests_textmode_containers
-          settings:
+          settings: &docker-apparmor
             CONTAINER_RUNTIMES: 'docker'
             SECURITY_MAC: 'apparmor'
       - container_host_docker_selinux:
           testsuite: extra_tests_textmode_containers
-          settings:
+          settings: &docker-selinux
             CONTAINER_RUNTIMES: 'docker'
             SECURITY_MAC: 'selinux'
+      - container_host_docker_stable_apparmor:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            <<: *docker-apparmor
+            CONTAINERS_DOCKER_FLAVOUR: 'stable'
+      - container_host_docker_stable_selinux:
+          testsuite: extra_tests_textmode_containers
+          settings:
+            <<: *docker-selinux
+            CONTAINERS_DOCKER_FLAVOUR: 'stable'
       - container_host_podman_apparmor:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Progress ticket: https://progress.opensuse.org/issues/176550
Test: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21195
SLE enablement: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/2067