### PR TITLE
Update BATS_SKIP variables

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -390,9 +390,9 @@ scenarios:
             MAX_JOB_TIME: '12000'
             QEMUCPUS: '2'
             QEMURAM: '4096'
-            PODMAN_BATS_SKIP: 'none'
-            PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 180-blkio'
-            PODMAN_BATS_SKIP_ROOT_REMOTE: '180-blkio'
+            PODMAN_BATS_SKIP: '180-blkio'
+            PODMAN_BATS_SKIP_ROOT_LOCAL: '030-run 120-load 410-selinux 520-checkpoint'
+            PODMAN_BATS_SKIP_ROOT_REMOTE: '410-selinux 520-checkpoint'
             PODMAN_BATS_SKIP_USER_LOCAL: '505-networking-pasta'
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_bats_testsuite:

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -416,9 +416,9 @@ scenarios:
             CONTAINER_RUNTIMES: 'podman'
             QEMUCPU: 'host'
             MAX_JOB_TIME: '12000'
-            BUILDAH_BATS_SKIP: 'commit run'
+            BUILDAH_BATS_SKIP: 'chroot sbom'
             BUILDAH_BATS_SKIP_ROOT: 'none'
-            BUILDAH_BATS_SKIP_USER: 'add basic bud copy overlay rmi sbom squash'
+            BUILDAH_BATS_SKIP_USER: 'add basic bud commit copy overlay rmi run squash'
       - container_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21194

```
$ susebats notok https://openqa.opensuse.org/tests/4854743
BUILDAH_BATS_SKIP='chroot sbom'
BUILDAH_BATS_SKIP_ROOT='none'
BUILDAH_BATS_SKIP_USER='add basic bud commit copy overlay rmi run squash'

$ susebats notok https://openqa.opensuse.org/tests/4854744
PODMAN_BATS_SKIP='none'
PODMAN_BATS_SKIP_ROOT_LOCAL='030-run 120-load 410-selinux 520-checkpoint'
PODMAN_BATS_SKIP_ROOT_REMOTE='410-selinux 520-checkpoint'
PODMAN_BATS_SKIP_USER_LOCAL='505-networking-pasta'
PODMAN_BATS_SKIP_USER_REMOTE='505-networking-pasta'
```