### PR TITLE
kernel: Remove LTP_COMMAND_EXCLUDE=ima_selinux

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -97,9 +97,7 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
-      - ltp_ima_load_policy:
-          settings:
-            LTP_COMMAND_EXCLUDE: ima_selinux
+      - ltp_ima_load_policy
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -260,9 +258,7 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
-      - ltp_ima_load_policy:
-          settings:
-            LTP_COMMAND_EXCLUDE: ima_selinux
+      - ltp_ima_load_policy
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -385,9 +381,7 @@ scenarios:
       - ltp_hugetlb
       - ltp_hyperthreading
       - ltp_ima
-      - ltp_ima_load_policy:
-          settings:
-            LTP_COMMAND_EXCLUDE: ima_selinux
+      - ltp_ima_load_policy
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:


### PR DESCRIPTION
The problem was marked into known issues yaml, therefore it does not have to be skipped.
https://github.com/openSUSE/kernel-qe/pull/12