### PR TITLE
Add Slowroll

### DIFF
--- a/job_groups.yaml
+++ b/job_groups.yaml
@@ -33,3 +33,4 @@
 125: opensuse_tumbleweed_riscv64
 126: opensuse_leap_16.0_images
 129: opensuse_leap_16.0
+131: opensuse_slowroll

--- a/job_groups/opensuse_slowroll.yaml
+++ b/job_groups/opensuse_slowroll.yaml
@@ -1,0 +1,35 @@
+############################################################
+#                         WARNING                          #
+#                                                          #
+#               This file is managed in GIT!               #
+#  Any changes via the openQA WebUI will get overwritten!  #
+#                                                          #
+#    https://github.com/os-autoinst/opensuse-jobgroups     #
+#            job_groups/opensuse_slowroll.yaml             #
+############################################################
+---
+defaults:
+  x86_64:
+    machine: 64bit
+    priority: 50
+products:
+  opensuse-Slowroll-DVD-x86_64:
+    distri: opensuse
+    flavor: DVD
+    version: Slowroll
+scenarios:
+  x86_64:
+    opensuse-Slowroll-DVD-x86_64:
+      - textmode:
+          machine: 64bit
+          priority: 40
+      - kde:
+          machine: 64bit
+          priority: 40
+      - uefi:
+          machine: 64bit
+          priority: 45
+      - gnome:
+          machine: 64bit
+          priority: 45
+      - mediacheck


### PR DESCRIPTION
Add the first openSUSE Slowroll tests into the development group.

This is not a complete final state but rather a start for openSUSE Slowroll testing.

* Related ticket: https://progress.opensuse.org/issues/177859
* Verification runs: https://openqa.opensuse.org/tests/4899863