### PR TITLE
Update mariadb-client BCI_IMAGE_MARKER to 11.7

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -611,7 +611,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: mariadb-client_11.6
+            BCI_IMAGE_MARKER: mariadb-client_11.7
             BCI_TEST_ENVS: all,mariadb,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/mariadb-client:latest
       - bci_389-ds_3.1_podman:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -508,7 +508,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: mariadb-client_11.6
+            BCI_IMAGE_MARKER: mariadb-client_11.7
             BCI_TEST_ENVS: all,mariadb,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/mariadb-client:latest
       - bci_389-ds_3.1_podman:


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/4887982
Temporarily fixes: https://progress.opensuse.org/issues/177709