### PR TITLE
kernel: Add ltp_ima_load_policy_selinux

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -98,6 +98,7 @@ scenarios:
       - ltp_hyperthreading
       - ltp_ima
       - ltp_ima_load_policy
+      - ltp_ima_load_policy_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -259,6 +260,7 @@ scenarios:
       - ltp_hyperthreading
       - ltp_ima
       - ltp_ima_load_policy
+      - ltp_ima_load_policy_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:
@@ -382,6 +384,7 @@ scenarios:
       - ltp_hyperthreading
       - ltp_ima
       - ltp_ima_load_policy
+      - ltp_ima_load_policy_selinux
       - ltp_input
       - ltp_ipc
       - ltp_kernel_misc:


### PR DESCRIPTION
Add a special variant, which differs from `ltp_ima_load_policy`:

```
LTP_COMMAND_PATTERN=ima_selinux
```

Test expects these kernel cmdline parameters: `security=selinux selinux=1 enforcing=1 ima_policy=critical_data` (SELinux ones added by Tumbleweed installation, `ima_policy=critical_data` is loaded via `GRUB_SELECT_FIRST_MENU=7`).

Verification run:
* https://openqa.opensuse.org/tests/4903582#step/ima_selinux/8
* https://openqa.opensuse.org/tests/4903583#step/ima_selinux/8

@Avinesh FYI