### PR TITLE
Use aarch64 as default machine instead of USBboot_aarch64

### DIFF
--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -14,7 +14,7 @@ defaults:
     machine: 64bit-2G
     priority: 55
   aarch64:
-    machine: USBboot_aarch64
+    machine: aarch64
     priority: 55
   ppc64le:
     machine: ppc64le


### PR DESCRIPTION
https://progress.opensuse.org/issues/178744