### PR TITLE
Make MariaDB BCI tag version independent

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -612,7 +612,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: mariadb-client_11.7
+            BCI_IMAGE_MARKER: mariadb-client_latest
             BCI_TEST_ENVS: all,mariadb,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/mariadb-client:latest
       - bci_389-ds_3.1_podman:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -508,7 +508,7 @@ scenarios:
           testsuite: null
           settings:
             <<: *bci
-            BCI_IMAGE_MARKER: mariadb-client_11.7
+            BCI_IMAGE_MARKER: mariadb-client_latest
             BCI_TEST_ENVS: all,mariadb,metadata
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/mariadb-client:latest
       - bci_389-ds_3.1_podman:


### PR DESCRIPTION
Switch from individual versions to the latest tag.

* Verification run: https://openqa.opensuse.org/tests/4919977