### PR TITLE
Skip 252-quadlet subtest

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -416,7 +416,7 @@ scenarios:
             PODMAN_BATS_SKIP: 'none'
             PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 520-checkpoint'
             PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'
-            PODMAN_BATS_SKIP_USER_LOCAL: '505-networking-pasta'
+            PODMAN_BATS_SKIP_USER_LOCAL: '252-quadlet 505-networking-pasta'
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_bats_testsuite:
           description: |-


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/178990

Problem: Subtest fails because of `# timeout: sending signal TERM to command ‘nc’`

Fix: Temporarily ignore `252-quadlet ` failure until https://github.com/containers/podman/commit/f8787bb219b3a25d689f6afc292e3abc19644869 makes it to latest podman version.

The above commit fixes the test issue by using ncat instead of nc.