### PR TITLE
Update BUILDAH_BATS_SKIP* for switch to runc

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -424,9 +424,9 @@ scenarios:
             QEMUCPU: 'host'
             QEMUCPUS: '2'
             MAX_JOB_TIME: '12000'
-            BUILDAH_BATS_SKIP: 'chroot sbom'
-            BUILDAH_BATS_SKIP_ROOT: 'none'
-            BUILDAH_BATS_SKIP_USER: 'add basic bud commit copy overlay rmi run squash'
+            BUILDAH_BATS_SKIP: 'bud chroot run sbom'
+            BUILDAH_BATS_SKIP_ROOT: 'from namespaces'
+            BUILDAH_BATS_SKIP_USER: 'add basic commit copy overlay rmi squash'
       - container_host_containerd:
           testsuite: extra_tests_textmode_containers
           settings:


### PR DESCRIPTION
Establish a new baseline for buildah upstream tests on o3.  These tests fail since the OCI_RUNTIME switch from `crun` to `runc` in Tumbleweed.

- Failing test: https://openqa.opensuse.org/tests/4934481
- Build with `OCI_RUNTIME=crun`: https://openqa.opensuse.org/tests/4934567

Will have to be updated when https://github.com/containers/buildah/issues/6071 is fixed.

```
$ susebats notok https://openqa.opensuse.org/tests/4934481
BUILDAH_BATS_SKIP: 'bud chroot run sbom'
BUILDAH_BATS_SKIP_ROOT: 'from namespaces'
BUILDAH_BATS_SKIP_USER: 'add basic commit copy overlay rmi squash'
```