### PR TITLE
Removed WSL bios scenarios

### DIFF
--- a/job_groups/opensuse_leap_15.6_wsl.yaml
+++ b/job_groups/opensuse_leap_15.6_wsl.yaml
@@ -31,14 +31,14 @@ scenarios:
                 5) Define users
                 6) Register SUT
                 7) Exit WSL
-          machine: [win10_64bit, win10_uefi, win11_uefi]
+          machine: [win10_uefi, win11_uefi]
           settings:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
       - wsl2-main: &wsl2_test
           testsuite: null
-          machine: [win10_64bit, win10_uefi, win11_uefi]
+          machine: [win10_uefi, win11_uefi]
           settings: &wsl2_settings
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1619,14 +1619,14 @@ scenarios:
                 5) Define users
                 6) Register SUT
                 7) Exit WSL
-          machine: [win10_64bit, win10_uefi, win11_uefi]
+          machine: [win10_uefi, win11_uefi]
           settings:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
       - wsl2-main: &wsl2_test
           testsuite: null
-          machine: [win10_64bit, win10_uefi, win11_uefi]
+          machine: [win10_uefi, win11_uefi]
           settings: &wsl2_settings
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/179086

In the last WSL bi-weekly meeting, it was finally stated by that there is no difference for our testing scope to test in both BIOS and UEFI machines.

Therefore, we are removing BIOS as it is a dead end that is not being supported by Microsoft anymore.