### PR TITLE
Fix NETAVARK_BATS_SKIP

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -419,7 +419,7 @@ scenarios:
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'
             SKOPEO_BATS_SKIP_USER: 'none'
-            NETAVARK_BATS_SKIP: '001-basic'
+            NETAVARK_BATS_SKIP: 'none'
       - container_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-


### PR DESCRIPTION
https://github.com/containers/netavark/pull/1191 was merged and now the `001-basic` test passes:

https://openqa.opensuse.org/tests/4943018#step/netavark_integration/117
