### PR TITLE
Ignore criu in runc test

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -419,7 +419,7 @@ scenarios:
             QEMUCPUS: '2'
             RETRY: '1'
             RUNC_BATS_SKIP: 'none'
-            RUNC_BATS_SKIP_ROOT: 'cgroups'
+            RUNC_BATS_SKIP_ROOT: 'cgroups checkpoint'
             RUNC_BATS_SKIP_USER: 'none'
             SKOPEO_BATS_SKIP: 'none'
             SKOPEO_BATS_SKIP_ROOT: 'none'


### PR DESCRIPTION
The CRIU functionality has been broken since the switch to SELinux.

Failing test: https://openqa.opensuse.org/tests/4967208/file/runc_integration-runc-root.tap