### PR TITLE
Fix BATS URL

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -417,7 +417,7 @@ scenarios:
             PODMAN_BATS_SKIP_ROOT_LOCAL: '120-load 200-pod 520-checkpoint'
             PODMAN_BATS_SKIP_ROOT_REMOTE: '520-checkpoint'
             PODMAN_BATS_SKIP_USER_LOCAL: '080-pause 195-run-namespaces 252-quadlet 505-networking-pasta'
-            PODMAN_BATS_SKIP_USER_REMOTE: '130-kill 505-networking-pasta'
+            PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_bats_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -405,7 +405,7 @@ scenarios:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed:latest'
       - container_host_podman_testsuite:
           description: |-
-            Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
@@ -420,7 +420,7 @@ scenarios:
             PODMAN_BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_bats_testsuite:
           description: |-
-            Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
@@ -437,7 +437,7 @@ scenarios:
       - container_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-
-            Maintainer: qe-c@suse.de https://confluence.suse.com/display/qasle/podman+upstream+tests
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
           settings:
             CONTAINER_RUNTIMES: 'podman'
             QEMUCPU: 'host'


### PR DESCRIPTION
- Update URL in BATS tests descriptions
- Update `PODMAN_BATS_SKIP_USER_REMOTE` as `130-kill` test is now passing: https://openqa.opensuse.org/tests/4973671#step/podman_integration/339

