### PR TITLE
Revert "Unset ENCRYPT variable for MicroOS bls with tpm"

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -221,7 +221,7 @@ scenarios:
           machine: uefi
           settings:
             # jeos-firstboot sets up FDE by default
-            ENCRYPT: '0'
+            ENCRYPT: '1'
             # Test with TPM enrollment
             QEMUTPM: 'instance'
             QEMU_DISABLE_SNAPSHOTS: '1'


### PR DESCRIPTION
Reverts os-autoinst/opensuse-jobgroups#636

https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21734 is the proper fix