### PR TITLE
Add OSS Repo to Slowroll

### DIFF
--- a/job_groups/opensuse_slowroll.yaml
+++ b/job_groups/opensuse_slowroll.yaml
@@ -8,6 +8,11 @@
 #            job_groups/opensuse_slowroll.yaml             #
 ############################################################
 ---
+.oss_repo: &oss_repo
+  MIRROR_PREFIX: 'http://download.opensuse.org'
+  REPO_OSS: 'slowroll/next/repo/oss/'
+  SUSEMIRROR: 'http://download.opensuse.org/slowroll/repo/oss/'
+
 defaults:
   x86_64:
     machine: 64bit
@@ -22,14 +27,18 @@ scenarios:
     opensuse-Slowroll-DVD-x86_64:
       - textmode:
           machine: 64bit
-          priority: 40
+          settings:
+            <<: *oss_repo
       - kde:
           machine: 64bit
-          priority: 40
+          settings:
+            <<: *oss_repo
       - uefi:
           machine: 64bit
-          priority: 45
+          settings:
+            <<: *oss_repo
       - gnome:
           machine: 64bit
-          priority: 45
+          settings:
+            <<: *oss_repo
       - mediacheck


### PR DESCRIPTION
Adds setting for OSS repo to Slowroll test runs.

* Related ticket: https://progress.opensuse.org/issues/177859
* Verification run: https://duck-norris.qe.suse.de/tests/14828#step/zypper_ar/2