### PR TITLE
Update BATS_SKIP* for podman

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -414,11 +414,11 @@ scenarios:
             QEMURAM: '4096'
             RETRY: '1'
             BATS_PACKAGE: 'podman'
-            BATS_SKIP: '030-run'
-            BATS_SKIP_ROOT_LOCAL: '120-load 200-pod 520-checkpoint'
-            BATS_SKIP_ROOT_REMOTE: '520-checkpoint'
+            BATS_SKIP: 'none'
+            BATS_SKIP_ROOT_LOCAL: '120-load'
+            BATS_SKIP_ROOT_REMOTE: 'none'
             BATS_SKIP_USER_LOCAL: '080-pause 195-run-namespaces 252-quadlet 505-networking-pasta'
-            BATS_SKIP_USER_REMOTE: '130-kill 505-networking-pasta'
+            BATS_SKIP_USER_REMOTE: '505-networking-pasta'
       - container_host_aardvark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
Update BATS_SKIP* for podman.

The tests are now passing after https://bugzilla.suse.com/show_bug.cgi?id=1238136 was fixed.

```
$ susebats notok https://openqa.opensuse.org/tests/5006530
BATS_SKIP: 'none'
BATS_SKIP_ROOT_LOCAL: '120-load'
BATS_SKIP_ROOT_REMOTE: 'none'
BATS_SKIP_USER_LOCAL: '080-pause 195-run-namespaces 252-quadlet 505-networking-pasta'
BATS_SKIP_USER_REMOTE: '505-networking-pasta'

```