### PR TITLE
Add BCI cosign container test run

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -751,6 +751,13 @@ scenarios:
             BCI_IMAGE_MARKER: tomcat_10
             BCI_TEST_ENVS: tomcat
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/tomcat:10
+      - bci_cosign_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: cosign
+            BCI_TEST_ENVS: cosign
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/cosign
       - extra_tests_ai_ml
       - yast_no_self_update
       - gnome-gdm:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -595,6 +595,13 @@ scenarios:
             BCI_IMAGE_MARKER: tomcat_10
             BCI_TEST_ENVS: tomcat
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/bci/tomcat:10
+      - bci_cosign_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: cosign
+            BCI_TEST_ENVS: cosign
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/cosign
       - create_hdd_textmode_secureboot:
           testsuite: null
           machine: aarch64-secureboot-opensuse-key


### PR DESCRIPTION
Test the BCI cosign container in Tumbleweed

Verification run: https://duck-norris.qe.suse.de/tests/14833#step/bci_test_podman/28 (ignore the test name)