### PR TITLE
podman_testsuite: Add 130-kill to BATS_SKIP_USER_REMOTE

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -418,10 +418,10 @@ scenarios:
             BATS_PACKAGE: 'podman'
             BATS_PATCHES: '25918'
             BATS_SKIP: 'none'
-            BATS_SKIP_ROOT_LOCAL: ''
+            BATS_SKIP_ROOT_LOCAL: 'none'
             BATS_SKIP_ROOT_REMOTE: 'none'
             BATS_SKIP_USER_LOCAL: '080-pause 252-quadlet 505-networking-pasta'
-            BATS_SKIP_USER_REMOTE: '505-networking-pasta'
+            BATS_SKIP_USER_REMOTE: '130-kill 505-networking-pasta'
       - container_host_aardvark_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
Add 130-kill to BATS_SKIP_USER_REMOTE

Flaky test on:
https://openqa.opensuse.org/tests/5022816/file/podman-bats-user-remote.tap