### PR TITLE
BATS_SKIP*: No need for special value none anymore

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -417,9 +417,9 @@ scenarios:
             RETRY: '1'
             BATS_PACKAGE: 'podman'
             BATS_PATCHES: '25918'
-            BATS_SKIP: 'none'
+            BATS_SKIP: ''
             BATS_SKIP_ROOT_LOCAL: '200-pod'
-            BATS_SKIP_ROOT_REMOTE: 'none'
+            BATS_SKIP_ROOT_REMOTE: ''
             BATS_SKIP_USER_LOCAL: '080-pause 252-quadlet 505-networking-pasta'
             BATS_SKIP_USER_REMOTE: '130-kill 505-networking-pasta'
       - container_host_aardvark_testsuite:
@@ -443,7 +443,7 @@ scenarios:
             QEMUCPUS: '2'
             RETRY: '1'
             BATS_PACKAGE: 'netavark'
-            BATS_SKIP: 'none'
+            BATS_SKIP: ''
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -454,9 +454,9 @@ scenarios:
             QEMUCPUS: '2'
             RETRY: '1'
             BATS_PACKAGE: 'runc'
-            BATS_SKIP: 'none'
+            BATS_SKIP: ''
             BATS_SKIP_ROOT: 'cgroups checkpoint'
-            BATS_SKIP_USER: 'none'
+            BATS_SKIP_USER: ''
       - container_host_skopeo_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
@@ -467,9 +467,9 @@ scenarios:
             QEMUCPUS: '2'
             RETRY: '1'
             BATS_PACKAGE: 'skopeo'
-            BATS_SKIP: 'none'
-            BATS_SKIP_ROOT: 'none'
-            BATS_SKIP_USER: 'none'
+            BATS_SKIP: ''
+            BATS_SKIP_ROOT: ''
+            BATS_SKIP_USER: ''
       - container_host_buildah_testsuite:
           testsuite: extra_tests_textmode_containers
           description: |-


### PR DESCRIPTION
No need for special value none anymore.

Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/21904