### PR TITLE
bats/podman: Add patch for 030-run

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -410,13 +410,14 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             # https://github.com/containers/podman/pull/25918 is needed for 195-run-namespaces
+            # https://github.com/containers/podman/pull/26017 is needed for 030-run
             CONTAINER_RUNTIMES: 'podman'
             MAX_JOB_TIME: '12000'
             QEMUCPUS: '2'
             QEMURAM: '4096'
             RETRY: '1'
             BATS_PACKAGE: 'podman'
-            BATS_PATCHES: '25918'
+            BATS_PATCHES: '25918 26017'
             BATS_SKIP: ''
             BATS_SKIP_ROOT_LOCAL: '200-pod'
             BATS_SKIP_ROOT_REMOTE: ''


### PR DESCRIPTION
Adds https://github.com/containers/podman/pull/26017 to `BATS_PATCHES` to fix spurious failures with podman + runc.

Verification run: https://openqa.opensuse.org/tests/5029065/file/podman-bats-root-local.tap