### PR TITLE
kernel: Add kdump to s390x

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -316,6 +316,9 @@ scenarios:
       - xfstests_nfs3-nfs
   s390x:
     opensuse-Tumbleweed-DVD-s390x:
+      - kdump:
+          settings:
+            KDUMP: '1'
       - ltp_controllers
       - ltp_cve
       - ltp_crypto_pty_commands:


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/182276
- Verification run: https://openqa.opensuse.org/tests/5056821