### PR TITLE
Add wsl2-install-msstore-legacy

### DIFF
--- a/job_groups/opensuse_leap_15.6_wsl.yaml
+++ b/job_groups/opensuse_leap_15.6_wsl.yaml
@@ -36,6 +36,7 @@ scenarios:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-main: &wsl2_test
           testsuite: null
           machine: [win10_uefi, win11_uefi]
@@ -53,10 +54,17 @@ scenarios:
             Basic WSL test Test scope:
                 1) Prepare WSL and other features in Windows
                 2) Install WSL image from the MS Store via CLI
-          settings:
+          settings: &msstore_settings
             <<: *wsl2_settings
             WSL_VERSION: 'openSUSE Leap 15.6'
             WSL_INSTALL_FROM: 'msstore'
+            WSL_FIRSTBOOT: 'jeos'
+      # Add MSStore Legacy Scenario
+      - wsl2-install-msstore_legacy:
+          <<: *wsl2_test
+          settings:
+            <<: [*msstore_settings, *wsl2_settings]
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-systemd:
           <<: *wsl2_test
           description: 'Enable and test systemd in WSL'

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1733,6 +1733,7 @@ scenarios:
             YAML_SCHEDULE: 'schedule/wsl/wsl_main.yaml'
             WSL_INSTALL_FROM: 'build'
             QEMU_ENABLE_SMBD: '1'
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-main: &wsl2_test
           testsuite: null
           machine: [win10_uefi, win11_uefi]
@@ -1750,10 +1751,17 @@ scenarios:
             Basic WSL test Test scope:
                 1) Prepare WSL and other features in Windows
                 2) Install WSL image from the MS Store via CLI
-          settings:
+          settings: &msstore_settings
             <<: *wsl2_settings
             WSL_VERSION: 'openSUSE Tumbleweed'
             WSL_INSTALL_FROM: 'msstore'
+            WSL_FIRSTBOOT: 'jeos'
+      # Add MSStore Legacy Scenario
+      - wsl2-install-msstore_legacy:
+          <<: *wsl2_test
+          settings:
+            <<: [*msstore_settings, *wsl2_settings]
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-systemd:
           <<: *wsl2_test
           description: 'Enable and test systemd in WSL'


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/180704

WSL installation from Microsoft Store now has two installation methods.
Legacy, which installs using yast-firstboot and Modern, which installs using jeos-firstboot. Both installation methods have to be tested. 

This PR is accompanied by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22411

This job-group MR will set current expected scenarios for Leap and TW and add corresponding yast/jeos firstboot variables. At the moment, there is an issue regarding WSL installation in Windows 10 for TW and Leap https://progress.opensuse.org/issues/185959 which needs to be investigated.