### PR TITLE
Enable podman BATS tests on aarch64

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -415,6 +415,17 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+      - container_host_podman_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'podman'
+            CONTAINER_RUNTIMES: 'podman'
+            MAX_JOB_TIME: '12000'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22672