### PR TITLE
Add WSL_FIRSTBOOT variable to wsl2-main and wsl2-systemd tests

### DIFF
--- a/job_groups/opensuse_leap_15.6_wsl.yaml
+++ b/job_groups/opensuse_leap_15.6_wsl.yaml
@@ -48,6 +48,7 @@ scenarios:
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
             WORKER_CLASS: 'wsl2'
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-install-msstore:
           <<: *wsl2_test
           description: |

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1745,6 +1745,7 @@ scenarios:
             QEMUCPU: 'host,kvm=off,vmx=on,hypervisor=off,hv_time,hv_relaxed,hv_vapic,hv_spinlocks=0x1fff,hv_frequencies,hv_reenlightenment,hv_vpindex,hv-synic,hv-stimer,hv-stimer-direct'
             QEMUMACHINE: 'q35,accel=whpx'
             WORKER_CLASS: 'wsl2'
+            WSL_FIRSTBOOT: 'yast'
       - wsl2-install-msstore:
           <<: *wsl2_test
           description: |


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/os-autoinst/opensuse-jobgroups/pull/687

Related ticket: https://progress.opensuse.org/issues/180704

This PR is accompanied by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22411