### PR TITLE
Increase QEMUCPUS=2 for container tests for poo#183962

### DIFF
--- a/job_groups/opensuse_leap_15.6_images.yaml
+++ b/job_groups/opensuse_leap_15.6_images.yaml
@@ -222,10 +222,12 @@ scenarios:
           settings:
             # Max size isn't that strict
             EXCLUDE_MODULES: "diskusage"
+            QEMUCPUS: '2'
       - jeos-container_image:
           settings:
             CONTAINER_IMAGE_TO_TEST: 'registry.opensuse.org/opensuse/leap/15.6/images/totest/containers/opensuse/leap:15.6'
             EXCLUDE_MODULES: "diskusage"
+            QEMUCPUS: '2'
       - jeos-filesystem:
           settings:
             EXCLUDE_MODULES: "diskusage"

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -130,16 +130,19 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - fips-container_host:
           machine: uefi-2G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - fips-container_host:
           machine: 64bit-2G
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - remote_ssh_controller:
           machine: 64bit-2G
           settings:
@@ -162,14 +165,17 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - container_host2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - container_host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
     microos-*-MicroOS-Image-x86_64:
       - microos:
           settings:

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -149,6 +149,7 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - remote_ssh_controller:
           settings:
             HDD_1: support_server_tumbleweed@aarch64.qcow2
@@ -167,19 +168,23 @@ scenarios:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - fips-container-host:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - container-host2microosnext:
           settings:
             HDD_1_URL: 'http://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2?foo=%BUILD%'
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
       - container-host-old2microosnext:
           settings:
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed
             K3S_INSTALL_UPSTREAM: '1'
+            QEMUCPUS: '2'
     microos-*-MicroOS-Image-aarch64:
       - microos:
           settings:


### PR DESCRIPTION
Increase QEMUCPUS=2 for container tests for https://progress.opensuse.org/issues/183962