### PR TITLE
Add runc & skopeo upstream tests on ppc64le

### DIFF
--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -81,6 +81,26 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
+      - container_host_runc_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'runc'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMUCPUS: '2'
+            QEMURAM: '4096'
+            RETRY: '1'
+      - container_host_skopeo_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'skopeo'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMUCPUS: '2'
+            QEMURAM: '4096'
+            RETRY: '1'
       - extra_tests_filesystem
       - yast2_ncurses:
           settings:


### PR DESCRIPTION
These run under 15 minutes and helped find a bug: https://github.com/opencontainers/runc/issues/4836

Verification runs:
- skopeo: https://openqa.opensuse.org/tests/5222260
- runc: https://openqa.opensuse.org/tests/5221586