### PR TITLE
Add aardvark-dns & netavark tests for ppc64le

### DIFF
--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -81,6 +81,26 @@ scenarios:
           testsuite: extra_tests_textmode_containers
           settings:
             CONTAINER_RUNTIMES: 'podman'
+      - container_host_aardvark_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'aardvark-dns'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
+      - container_host_netavark_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'netavark'
+            CONTAINER_RUNTIMES: 'podman'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22961