### PR TITLE
Revert "Remove ppc64le jobs for podman_testsuite*"

### DIFF
--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -101,6 +101,29 @@ scenarios:
             QEMURAM: '4096'
             QEMUCPUS: '2'
             RETRY: '1'
+      - container_host_podman_testsuite:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'podman'
+            CONTAINER_RUNTIMES: 'podman'
+            MAX_JOB_TIME: '12000'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
+      - container_host_podman_testsuite_crun:
+          description: |-
+            Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats
+          testsuite: extra_tests_textmode_containers
+          settings:
+            BATS_PACKAGE: 'podman'
+            CONTAINER_RUNTIMES: 'podman'
+            MAX_JOB_TIME: '12000'
+            OCI_RUNTIME: 'crun'
+            QEMURAM: '4096'
+            QEMUCPUS: '2'
+            RETRY: '1'
       - container_host_runc_testsuite:
           description: |-
             Maintainer: qe-c@suse.de https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/containers/bats


### PR DESCRIPTION
Re-enable ppc64le jobs for podman.

Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22980

Verification runs:
- podman with runc: https://openqa.opensuse.org/tests/5242648
- podman with crun: https://openqa.opensuse.org/tests/5242649

Failing due to https://github.com/checkpoint-restore/criu/issues/2705