### PR TITLE
Drop Kubic + oS:F:PPC: Add tests for microos-Tumbleweed-MicroOS-Image-ppc64le

### DIFF
--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -25,10 +25,6 @@ products:
     distri: microos
     flavor: DVD
     version: '*'
-  microos-*-Kubic-DVD-ppc64le:
-    distri: microos
-    flavor: Kubic-DVD
-    version: '*'
 scenarios:
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
@@ -163,7 +159,3 @@ scenarios:
     microos-*-DVD-ppc64le:
       - rcshell
       - microos_10G-disk
-    microos-*-Kubic-DVD-ppc64le:
-      - rcshell
-      - kubeadm:
-          machine: ppc64le-4G-HD40G

--- a/job_groups/opensuse_tumbleweed_powerpc.yaml
+++ b/job_groups/opensuse_tumbleweed_powerpc.yaml
@@ -25,6 +25,10 @@ products:
     distri: microos
     flavor: DVD
     version: '*'
+  microos-Tumbleweed-MicroOS-Image-ppc64le:
+    distri: microos
+    flavor: MicroOS-Image
+    version: Tumbleweed
 scenarios:
   ppc64le:
     opensuse-Tumbleweed-DVD-ppc64le:
@@ -159,3 +163,9 @@ scenarios:
     microos-*-DVD-ppc64le:
       - rcshell
       - microos_10G-disk
+    microos-Tumbleweed-MicroOS-Image-ppc64le:
+      - microos:
+          settings:
+            HDD_2: 'ignition.qcow2'
+            NUMDISKS: '2'
+      - microos-wizard

--- a/job_groups/opensuse_tumbleweed_s390x.yaml
+++ b/job_groups/opensuse_tumbleweed_s390x.yaml
@@ -21,10 +21,6 @@ products:
     distri: microos
     flavor: DVD
     version: '*'
-  microos-*-Kubic-DVD-s390x:
-    distri: microos
-    flavor: Kubic-DVD
-    version: '*'
 scenarios:
   s390x:
     opensuse-Tumbleweed-DVD-s390x:


### PR DESCRIPTION
https://openqa.opensuse.org/tests/overview?arch=ppc64le&flavor=MicroOS-Image&distri=microos&version=Tumbleweed&build=20250818&groupid=38