### PR TITLE
Tumbleweed s390x: Drop fixed modules from EXCLUDE_MODULES

### DIFF
--- a/job_groups/opensuse_tumbleweed_s390x.yaml
+++ b/job_groups/opensuse_tumbleweed_s390x.yaml
@@ -41,5 +41,5 @@ scenarios:
           settings:
             EXTRABOOTPARAMS: hvc_iucv=8
             EXTRATEST: prepare,console
-            # command_not_found: Not available, *_ipv6: poo#184040, lshw: poo#184138
-            EXCLUDE_MODULES: command_not_found,curl_ipv6,wget_ipv6,lshw
+            # *_ipv6: poo#184040
+            EXCLUDE_MODULES: curl_ipv6,wget_ipv6


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/5257295