### PR TITLE
tw: aarch64: Increase disk size for jeos-extra

### DIFF
--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -1041,7 +1041,7 @@ scenarios:
           machine: aarch64_cpu_max-HD20G
           priority: 45
       - jeos-extra:
-          machine: aarch64-HD20G
+          machine: aarch64-HD24G
           priority: 45
           settings:
             QEMURAM: '4096'


### PR DESCRIPTION
`kdump_and_crash` test requires lots of space and we are missing ~50 MB.

Test showing the missing space: https://openqa.opensuse.org/tests/5271019#step/kdump_and_crash/23