### PR TITLE
Tumbleweed: give up on "cirrus" graphics

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -253,9 +253,6 @@ scenarios:
           machine: 64bit
           priority: 40
       - kde:
-          machine: 64bit_cirrus-2G
-          priority: 40
-      - kde:
           machine: Laptop_64
           priority: 40
       - uefi:
@@ -270,9 +267,6 @@ scenarios:
       - gnome:
           machine: 64bit
           priority: 45
-      # - gnome:
-      #   machine: 64bit_cirrus
-      #   priority: 45
       - minimalx:
           machine: 64bit
           priority: 45
@@ -824,11 +818,9 @@ scenarios:
           machine: 64bit_win
       - kde-sddm
       - gnome+import_ssh_keys:
-          machine: 64bit_cirrus
           settings:
             HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
       - gnome+do_not_import_ssh_keys:
-          machine: 64bit_cirrus-2G
           settings:
             HDD_1: opensuse-leap-updated-%ARCH%-%DESKTOP%.qcow2
       - autoyast_y2_firstboot


### PR DESCRIPTION
With kernel 6.16, some legacy code/hacks have been removed from the cirrus driver

As a consequence, openQA can only use cirrus in 800x600

We have no interest in needling all tests in multiple resolutions, so give up https://bugzilla.opensuse.org/show_bug.cgi?id=1247994