### PR TITLE
More RISC-V tests

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -49,3 +49,5 @@ scenarios:
             EXCLUDE_MODULES: libzypp_config
             LTP_ENV: 'TMPDIR=/var/tmp,LTP_TIMEOUT_MUL=2,LTP_RUNTIME_MUL=2'
             LTP_TAINT_EXPECTED: '0x13801'
+            # Too performance sensitive for software emulation
+            LTP_COMMAND_EXCLUDE: '(epoll_wait|epoll_pwait|select|prctl09).*'

--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -15,12 +15,25 @@ defaults:
     machine: riscv64_cpu_max
     priority: 50
 products:
+  opensuse-Tumbleweed-DVD-riscv64:
+    distri: opensuse
+    flavor: DVD
+    version: Tumbleweed
+  opensuse-Tumbleweed-NET-riscv64:
+    distri: opensuse
+    flavor: NET
+    version: Tumbleweed
   opensuse-Tumbleweed-JeOS-for-RISCV-riscv64:
     distri: opensuse
     flavor: JeOS-for-RISCV
     version: Tumbleweed
 scenarios:
   riscv64:
+    opensuse-Tumbleweed-DVD-riscv64:
+      - textmode
+    opensuse-Tumbleweed-NET-riscv64:
+      - create_hdd_textmode
+      - extra_tests_filesystem
     opensuse-Tumbleweed-JeOS-for-RISCV-riscv64:
       - jeos:
           settings:


### PR DESCRIPTION
VRs: https://openqa.opensuse.org/tests/overview?distri=microos&distri=opensuse&version=Tumbleweed&build=20250827&arch=riscv64