### PR TITLE
Follow up to #710: Pin more tests to Legacy bios

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1529,11 +1529,13 @@ scenarios:
       - jeos-ltp-syscalls-ipc:
           machine: uefi_virtio-2G
       - jeos-ssh-enroll-server:
+          machine: 64bit
           settings:
             +HDD_1: 'support_server_tumbleweed@64bit.qcow2'
             SSH_ENROLL_PAIR: '1'
             YAML_SCHEDULE: schedule/jeos/supportserver.yaml
       - jeos-ssh-enroll-wizard:
+          machine: 64bit
           settings:
             PARALLEL_WITH: jeos-ssh-enroll-server
             YAML_SCHEDULE: schedule/jeos/ssh-enroll.yaml

--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1223,6 +1223,7 @@ scenarios:
       - remote_ssh_target:
           machine: 64bit
       - remote-desktop-client4:
+          machine: 64bit
           description: ''
           settings:
             BOOTFROM: c
@@ -1238,6 +1239,7 @@ scenarios:
             WORKER_CLASS: tap
           testsuite: null
       - remote-desktop-supportserver4:
+          machine: 64bit
           description: ''
           settings:
             BOOTFROM: c


### PR DESCRIPTION
- **Pin remote-desktop tests to legacy**
- **Pin jeos enrollment tests to legacy**

Follows #710
