### PR TITLE
kernel: Add ltp_ima and ltp_ima_load_policy

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -335,6 +335,8 @@ scenarios:
       - ltp_crypto_pty_commands:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'
+      - ltp_ima
+      - ltp_ima_load_policy
       - ltp_kernel_misc:
           settings:
             LTP_TAINT_EXPECTED: '0x13801'


### PR DESCRIPTION
IBM will be happy we test it :).

Tested: 
- https://openqa.opensuse.org/tests/5284781
- https://openqa.opensuse.org/tests/5284782 (note here broken, but on all archs due https://progress.opensuse.org/issues/188250: https://openqa.opensuse.org/tests/overview?build=ima_kexec-check-reuse-cmdline)