### PR TITLE
Tumbleweed RISC-V: cleanup

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -62,5 +62,3 @@ scenarios:
             EXCLUDE_MODULES: libzypp_config
             LTP_ENV: 'TMPDIR=/var/tmp,LTP_TIMEOUT_MUL=2,LTP_RUNTIME_MUL=2'
             LTP_TAINT_EXPECTED: '0x13801'
-            # Too performance sensitive for software emulation
-            LTP_COMMAND_EXCLUDE: '(epoll_wait|epoll_pwait|select|prctl09).*'


### PR DESCRIPTION
It should be merged after https://github.com/openSUSE/kernel-qe/pull/25 is merged. That's why it's a draft.
Why the cleanup: it's a standard way how to handle bugs/failures in LTP tests. It allows better setup than just always skip the test.

<s>Why KOTD: It's worth to see bugs (both in kernel and in LTP tests) for upcoming riscv64 kernel.</s>
(Originally added as _Tumbleweed RISC-V: cleanup and add jeos-ltp-syscalls-kotd_.)