### PR TITLE
Tumbleweed RISC-V: Switch default machine from riscv64_cpu_max to riscv64

### DIFF
--- a/job_groups/opensuse_tumbleweed_riscv64.yaml
+++ b/job_groups/opensuse_tumbleweed_riscv64.yaml
@@ -12,7 +12,7 @@
 
 defaults:
   riscv64:
-    machine: riscv64_cpu_max
+    machine: riscv64
     priority: 50
 products:
   opensuse-Tumbleweed-DVD-riscv64:


### PR DESCRIPTION
The additional CPU features have a noticable performance impact, causing some tests to fail. Default to a more basic machine type and (in the future) run selected tests on riscv64_cpu_max.