### PR TITLE
Schedule Himmelblau IDM tests

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -835,6 +835,20 @@ scenarios:
             BCI_IMAGE_MARKER: cosign
             BCI_TEST_ENVS: cosign
       - extra_tests_ai_ml
+      - extra_tests_himmelblau:
+          testsuite: null
+          settings:
+            MACHINE: uefi
+            EXTRATEST: himmelblau
+            HIMMELBLAU_ALLOWED_USERS: 'bernhard.test'
+            HIMMELBLAU_ALLOWED_DOMAINS: 'azureemea.geekos.io'
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            NOVIDEO: "1"
+            VIDEOMODE: "text"
+            START_AFTER_TEST: "create_hdd_textmode"
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
+            UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2'
       - yast_no_self_update
       - gnome-gdm:
           machine: 64bit

--- a/job_groups/opensuse_tumbleweed_aarch64.yaml
+++ b/job_groups/opensuse_tumbleweed_aarch64.yaml
@@ -841,6 +841,20 @@ scenarios:
       - extra_tests_ai_ml
       - extra_tests_ai_ml:
           machine: aarch64_lse_smp4
+      - extra_tests_himmelblau:
+          testsuite: null
+          settings:
+            MACHINE: aarch64
+            EXTRATEST: himmelblau
+            HIMMELBLAU_ALLOWED_USERS: 'bernhard.test'
+            HIMMELBLAU_ALLOWED_DOMAINS: 'azureemea.geekos.io'
+            BOOT_HDD_IMAGE: "1"
+            DESKTOP: "textmode"
+            NOVIDEO: "1"
+            VIDEOMODE: "text"
+            START_AFTER_TEST: "create_hdd_textmode"
+            HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2'
+            UEFI_PFLASH_VARS: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%-uefi-vars.qcow2'
       - yast2_firstboot
       - yast2_firstboot_custom
       - wireguard_server:


### PR DESCRIPTION
This PR schedules our Himmelblau IDM tests for Tumbleweed.

Progress: https://progress.opensuse.org/issues/183203

VRs:
- general functionality - http://dirtman.qe.prg2.suse.org/tests/84
- Scheduled in TW Development Job Group: 
   - x86_64 https://openqa.opensuse.org/tests/5369230# 
   - aarch64 https://openqa.opensuse.org/tests/5369269#
- Auto-scheduled for TW - https://openqa.opensuse.org/tests/5370396