### PR TITLE
Override network parameters for zVM

### DIFF
--- a/job_groups/opensuse_leap_16.0.yaml
+++ b/job_groups/opensuse_leap_16.0.yaml
@@ -21,6 +21,8 @@ defaults:
     priority: 55
   s390x:
     machine: s390x-zVM-vswitch-l2
+    settings:
+      +S390_NETWORK_PARAMS: rd.zdev=qeth,0.0.0A00:0.0.0A01:0.0.0A02,layer2=0,portno=0 nameserver=10.150.1.11
     priority: 55
 products:
   opensuse-online-installer-x86_64:


### PR DESCRIPTION
Failure: https://openqa.opensuse.org/tests/5320272
VR: https://openqa.opensuse.org/tests/5317086#step/bootloader_start/55
