### PR TITLE
Schedule security_pam tests on TW

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -1092,6 +1092,7 @@ scenarios:
             DESKTOP: textmode
             YAML_SCHEDULE: schedule/security/build_nested_hdd.yaml
             PUBLISH_HDD_1: '%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%_nested_l2.qcow2'
+      - security_pam
       - security_tpm2
       - security_tpm2_uefi:
           testsuite: security_tpm2


### PR DESCRIPTION
This is to bring back `security_pam` tests that were removed by mistake

VR: https://openqa.opensuse.org/tests/5319117
