### PR TITLE
Add postgres17

### DIFF
--- a/job_groups/opensuse_tumbleweed.yaml
+++ b/job_groups/opensuse_tumbleweed.yaml
@@ -775,6 +775,13 @@ scenarios:
             BCI_IMAGE_MARKER: postgres_16
             BCI_TEST_ENVS: postgres
             CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/postgres:16
+      - bci_postgres_17_podman:
+          testsuite: null
+          settings:
+            <<: *bci
+            BCI_IMAGE_MARKER: postgres_17
+            BCI_TEST_ENVS: postgres
+            CONTAINER_IMAGE_TO_TEST: registry.opensuse.org/opensuse/factory/totest/containers/opensuse/bci/postgres:17
       - bci_grafana_11_podman:
           testsuite: null
           settings:


### PR DESCRIPTION
Adds the job group definition to test the postgres17 BCI container.

* Verification run: https://openqa.opensuse.org/tests/5350788