### PR TITLE
Revert "kernel: Add kselftests-bpf-progs"

### DIFF
--- a/job_groups/opensuse_tumbleweed_kernel.yaml
+++ b/job_groups/opensuse_tumbleweed_kernel.yaml
@@ -380,7 +380,6 @@ scenarios:
       - kernel-live-patching
       - kselftests-livepatch
       - kselftests-bpf
-      - kselftests-bpf-progs
       - ltp_aio_stress
       - ltp_aiodio_part1
       - ltp_aiodio_part2


### PR DESCRIPTION
This reverts commit 9695840dd67851ea5e5f1307c601af4cc490930b.

This test is very long and a running target, breaking at every major and minor versions of the kernel. Let's move it to the development group for now.